### PR TITLE
Fix training preview script

### DIFF
--- a/en/training.php
+++ b/en/training.php
@@ -20,7 +20,7 @@ include '../ecobricks_env.php';
 $conn->set_charset("utf8mb4");
 
 
-$trainingId = $_GET['training_id'];
+$trainingId = isset($_GET["training_id"])?$_GET["training_id"]:(isset($_GET["id"])?$_GET["id"]:0);
 
 $sql = "SELECT * FROM tb_trainings WHERE training_id = ?";
 $stmt = $conn->prepare($sql);

--- a/en/welcome.php
+++ b/en/welcome.php
@@ -288,7 +288,7 @@ https://github/globalecobrickalliance/ecobricks.org
 
 
 
- <script src="../scripts/2024-landing-scripts.js.js"></script>
+ <script src="../scripts/2024-landing-scripts.js"></script>
 
 
 </body>

--- a/es/welcome-off.php
+++ b/es/welcome-off.php
@@ -233,7 +233,7 @@ https://github/globalecobrickalliance/ecobricks.org
 
 
 
- <script src="../scripts/2024-landing-scripts.js.js"></script>
+ <script src="../scripts/2024-landing-scripts.js"></script>
 
 
 

--- a/es/welcome.php
+++ b/es/welcome.php
@@ -271,7 +271,7 @@ https://github/globalecobrickalliance/ecobricks.org
 
 
 
- <script src="../scripts/2024-landing-scripts.js.js"></script>
+ <script src="../scripts/2024-landing-scripts.js"></script>
 
 
 </body>

--- a/fr/welcome.php
+++ b/fr/welcome.php
@@ -275,7 +275,7 @@ https://github/globalecobrickalliance/ecobricks.org
 
 
 
- <script src="../scripts/2024-landing-scripts.js.js"></script>
+ <script src="../scripts/2024-landing-scripts.js"></script>
 
 
 </body>

--- a/id/welcome.php
+++ b/id/welcome.php
@@ -271,7 +271,7 @@ https://github/globalecobrickalliance/ecobricks.org
 
 
 
- <script src="../scripts/2024-landing-scripts.js.js"></script>
+ <script src="../scripts/2024-landing-scripts.js"></script>
 
 
 </body>

--- a/scripts/2024-landing-scripts.js
+++ b/scripts/2024-landing-scripts.js
@@ -84,7 +84,7 @@ function ecobrickPreview(brik_serial, weight, owner, location) {
 
   function trainingPreview(id, title, country, participants, trainer) {
       // Construct the training image URL (assumes filename pattern similar to ecobricks)
-      var imageUrl = 'https://gobrik.com/trainings/training-' + id + '-file.webp';
+      var imageUrl = 'https://gobrik.com/trainings/photos/training-' + id + '-file.webp';
 
       const modal = document.getElementById('form-modal-message');
       const contentBox = modal.querySelector('.modal-content-box');
@@ -116,7 +116,7 @@ function ecobrickPreview(brik_serial, weight, owner, location) {
           'Country: ' + country + '<br>' +
           'Participants: ' + participants + '<br>' +
           'Lead Trainer: ' + trainer + '</p>' +
-          '<a href="https://gobrik.com/trainings.php?id=' + id + '" class="preview-btn" style="margin-bottom: 50px;height: 25px;padding: 5px;border: none;padding: 5px 12px;">ℹ️ View Full Details</a>';
+          '<a href="https://ecobricks.org/en/training.php?training_id=' + id + '" class="preview-btn" style="margin-bottom: 50px;height: 25px;padding: 5px;border: none;padding: 5px 12px;">ℹ️ View Full Details</a>';
       photoContainer.appendChild(details);
 
       // Final modal setup


### PR DESCRIPTION
## Summary
- correct the script path for the landing page JS
- ensure all localized welcome pages load the preview functions
- use `training_id` parameter for preview links

## Testing
- `node --check scripts/2024-landing-scripts.js`
- `php -l en/training.php` *(fails: `php` not found)*


------
https://chatgpt.com/codex/tasks/task_b_683eb97da2e88323b35ab09f5275b12d