### PR TITLE
Update training preview path and link

### DIFF
--- a/en/welcome.php
+++ b/en/welcome.php
@@ -104,18 +104,19 @@ https://github/globalecobrickalliance/ecobricks.org
             // Output data of each row
             while ($row = $result->fetch_assoc()) {
                 // Fallback-safe values
-                $photo     = htmlspecialchars($row["training_photo0_tmb"] ?? '');
-                $title     = htmlspecialchars($row["training_title"] ?? '');
-                $country   = htmlspecialchars($row["training_country"] ?? '');
-                $participants = htmlspecialchars($row["no_participants"] ?? '');
-                $trainer   = htmlspecialchars($row["lead_trainer"] ?? '');
-                $id        = htmlspecialchars($row["training_id"] ?? '');
+                $photo       = htmlspecialchars($row["training_photo0_tmb"] ?? '', ENT_QUOTES);
+                $photo_main  = htmlspecialchars($row["training_photo0_main"] ?? '', ENT_QUOTES);
+                $title       = htmlspecialchars($row["training_title"] ?? '', ENT_QUOTES);
+                $country     = htmlspecialchars($row["training_country"] ?? '', ENT_QUOTES);
+                $participants = htmlspecialchars($row["no_participants"] ?? '', ENT_QUOTES);
+                $trainer     = htmlspecialchars($row["lead_trainer"] ?? '', ENT_QUOTES);
+                $id          = htmlspecialchars($row["training_id"] ?? '', ENT_QUOTES);
 
                 echo '<div class="gal-project-photo">
                         <div class="photo-box">
                             <img src="https://gobrik.com/' . $photo . '?v=2"
                                  alt="' . $title . ' in ' . $country . ' had ' . $participants . ' participants"
-                                 onclick="trainingPreview(\'' . $id . '\', \'' . $title . '\', \'' . $country . '\', \'' . $participants . '\', \'' . $trainer . '\')"
+                                 onclick="trainingPreview(\'' . $id . '\', \'' . $title . '\', \'' . $country . '\', \'' . $participants . '\', \'' . $trainer . '\', \'' . $photo_main . '\')"
                                  title="' . $title . ' in ' . $country . ' had ' . $participants . ' participants">
                         </div>
                     </div>';
@@ -292,10 +293,9 @@ https://github/globalecobrickalliance/ecobricks.org
 
 <script>
 
-  function trainingPreview(id, title, country, participants, trainer) {
-    alert('hello!');
-      // Construct the training image URL (assumes filename pattern similar to ecobricks)
-      var imageUrl = 'https://gobrik.com/trainings/photos/training-' + id + '-file.webp';
+  function trainingPreview(id, title, country, participants, trainer, photo) {
+      // Construct the training image URL based on the provided photo path
+      var imageUrl = 'https://gobrik.com/' + photo;
 
       const modal = document.getElementById('form-modal-message');
       const contentBox = modal.querySelector('.modal-content-box');
@@ -327,7 +327,7 @@ https://github/globalecobrickalliance/ecobricks.org
           'Country: ' + country + '<br>' +
           'Participants: ' + participants + '<br>' +
           'Lead Trainer: ' + trainer + '</p>' +
-          '<a href="https://ecobricks.org/en/training.php?training_id=' + id + '" class="preview-btn" style="margin-bottom: 50px;height: 25px;padding: 5px;border: none;padding: 5px 12px;">ℹ️ View Full Details</a>';
+          '<a href="https://ecobricks.org/en/training.php?id=' + id + '" class="preview-btn" style="margin-bottom: 50px;height: 25px;padding: 5px;border: none;padding: 5px 12px;">ℹ️ View Full Details</a>';
       photoContainer.appendChild(details);
 
       // Final modal setup


### PR DESCRIPTION
## Summary
- pass the main training photo path to `trainingPreview`
- adjust the training modal to use the provided path
- update the View Training link to `training.php?id=...`

## Testing
- `php -l en/welcome.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_683ecbd6d7a88323853b7e8f8988541e