### PR TITLE
Restrict training gallery to showable reports

### DIFF
--- a/en/welcome.php
+++ b/en/welcome.php
@@ -97,7 +97,7 @@ https://github/globalecobrickalliance/ecobricks.org
     <div class="gallery-flex-container">
         <?php
         // Updated SQL query to include a WHERE clause and a LIMIT
-        $sql = "SELECT * FROM tb_trainings WHERE ready_to_show = 1 ORDER BY training_id DESC LIMIT 20;";
+        $sql = "SELECT * FROM tb_trainings WHERE ready_to_show = 1 AND show_report = 1 ORDER BY training_id DESC LIMIT 20;";
         $result = $conn->query($sql);
 
         if ($result->num_rows > 0) {

--- a/es/welcome.php
+++ b/es/welcome.php
@@ -86,7 +86,7 @@ https://github/globalecobrickalliance/ecobricks.org
     <div class="gallery-flex-container">
         <?php
         // Updated SQL query to include a WHERE clause and a LIMIT
-        $sql = "SELECT * FROM tb_trainings WHERE ready_to_show = 1 ORDER BY training_id DESC LIMIT 40;";
+        $sql = "SELECT * FROM tb_trainings WHERE ready_to_show = 1 AND show_report = 1 ORDER BY training_id DESC LIMIT 40;";
         $result = $conn->query($sql);
 
         if ($result->num_rows > 0) {

--- a/fr/welcome.php
+++ b/fr/welcome.php
@@ -87,7 +87,7 @@ https://github/globalecobrickalliance/ecobricks.org
     <div class="gallery-flex-container">
         <?php
         // Updated SQL query to include a WHERE clause and a LIMIT
-        $sql = "SELECT * FROM tb_trainings WHERE ready_to_show = 1 ORDER BY training_id DESC LIMIT 40;";
+        $sql = "SELECT * FROM tb_trainings WHERE ready_to_show = 1 AND show_report = 1 ORDER BY training_id DESC LIMIT 40;";
         $result = $conn->query($sql);
 
         if ($result->num_rows > 0) {

--- a/id/welcome.php
+++ b/id/welcome.php
@@ -86,7 +86,7 @@ https://github/globalecobrickalliance/ecobricks.org
     <div class="gallery-flex-container">
         <?php
         // Updated SQL query to include a WHERE clause and a LIMIT
-        $sql = "SELECT * FROM tb_trainings WHERE ready_to_show = 1 ORDER BY training_id DESC LIMIT 40;";
+        $sql = "SELECT * FROM tb_trainings WHERE ready_to_show = 1 AND show_report = 1 ORDER BY training_id DESC LIMIT 40;";
         $result = $conn->query($sql);
 
         if ($result->num_rows > 0) {


### PR DESCRIPTION
## Summary
- update training galleries on all welcome pages to only fetch rows where `show_report` is enabled

## Testing
- `php -l en/welcome.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68467075a0648323af5d571cb3e0527f