### PR TITLE
Fix layout and start gallery scroll after load

### DIFF
--- a/includes/welcome-inc.php
+++ b/includes/welcome-inc.php
@@ -643,7 +643,8 @@ margin-left: 0px;
     background-position: center;
     position: relative;
     overflow: hidden;
-    margin-top: -40px;
+    /* Adjust margin to prevent overlap with preceding section */
+    margin-top: 20px;
 
     margin-bottom: 10px;
     margin-right: 20px;

--- a/scripts/2024-landing-scripts.js
+++ b/scripts/2024-landing-scripts.js
@@ -25,9 +25,13 @@
         requestAnimationFrame(scroll);
     }
 
-    const galleryBlock = document.querySelector('.gallery10-content-block');
-    const galleryWidth = galleryBlock.scrollWidth; // Get the total width of the gallery
-    slowScrollLeft(galleryBlock, galleryWidth, 45000); // Scroll the full width over 15000 milliseconds
+    window.addEventListener('load', () => {
+        const galleryBlock = document.querySelector('.gallery10-content-block');
+        if (galleryBlock) {
+            const galleryWidth = galleryBlock.scrollWidth; // Get the total width of the gallery
+            slowScrollLeft(galleryBlock, galleryWidth, 45000); // Scroll the full width over 45 seconds
+        }
+    });
 
 
 


### PR DESCRIPTION
## Summary
- ensure `featured-project-gallery` doesn't overlap previous section by removing negative top margin
- start top-tens gallery animation after window load to ensure width is calculated correctly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6847d5013364832386f745415725e10a