### PR TITLE
Fix translation script path and remove early switch

### DIFF
--- a/header-2024.php
+++ b/header-2024.php
@@ -94,7 +94,7 @@ window.onload = function() {
     window.currentLanguage = ''; // This makes currentLanguage globally accessible
     // Now set the value of currentLanguage
     window.currentLanguage = '<?php echo ($lang); ?>'; // Default language code
-    switchLanguage(window.currentLanguage);
+    // Translation scripts will trigger switchLanguage once loaded
     // updateLogoColor();
     //checkRegistrationStatus();
     window.subSource = 'ecobricks-org'; // Make subSource globally accessible

--- a/language-switcher.js
+++ b/language-switcher.js
@@ -82,13 +82,13 @@ function loadTranslationScripts(lang, page, callback) {
 
     // Core UI translations
     const coreScript = document.createElement('script');
-    coreScript.src = `../translations/core-texts-${lang}.js?v=${version}`;
+    coreScript.src = `../translations/core-${lang}-translation.js?v=${version}`;
     coreScript.onload = scriptLoaded;
     document.head.appendChild(coreScript);
 
     // Page-specific translations
     const pageScript = document.createElement('script');
-    pageScript.src = `../translations/${page}-${lang}.js?v=${version}`;
+    pageScript.src = `../translations/${page}-${lang}-translation.js?v=${version}`;
     pageScript.onload = scriptLoaded;
     document.head.appendChild(pageScript);
 


### PR DESCRIPTION
## Summary
- update translation loader paths for new naming pattern
- let translation loader trigger switchLanguage once translations are ready

## Testing
- `node -v`
- `php -l header-2024.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684a43423ef88323b5080810a325e51b