### PR TITLE
Fix training meta and sections

### DIFF
--- a/en/training.php
+++ b/en/training.php
@@ -92,27 +92,22 @@ for ($i = 0; $i <= 6; $i++) {
                               <br>';
                     }
                     
-                    if (!empty($array["training_agenda"])) {
-                        echo '<h3><p>Training Agenda</p></h3>
-                              <p>'. $array["training_agenda"] .'</p>
-                              <br>';
-                    }
                     
                     if (!empty($array["training_success"])) {
                         echo '<h3><p>Success Story</p></h3>
-                              <p>'. $array["training_success"] .'</p>
+                              <p>'. nl2br($array["training_success"]) .'</p>
                               <br>';
                     }
                     
                     if (!empty($array["training_challenges"])) {
                         echo '<h3><p>Challenges</p></h3>
-                              <p>'. $array["training_challenges"] .'</p>
+                              <p>'. nl2br($array["training_challenges"]) .'</p>
                               <br>';
                     }
                     
                     if (!empty($array["training_lessons_learned"])) {
                         echo '<h3><p>Lessons Learned</p></h3>
-                              <p>'. $array["training_lessons_learned"] .'</p>
+                              <p>'. nl2br($array["training_lessons_learned"]) .'</p>
                               <br>';
                     }
                     

--- a/meta/training-en.php
+++ b/meta/training-en.php
@@ -5,7 +5,7 @@
 include '../ecobricks_env.php';
 
 
-$trainingId = $_GET['training_id'];
+$trainingId = isset($_GET['training_id']) ? $_GET['training_id'] : (isset($_GET['id']) ? $_GET['id'] : 0);
 
 $sql = "SELECT * FROM tb_trainings WHERE training_id = '" . $trainingId . "'";
 

--- a/meta/training-es.php
+++ b/meta/training-es.php
@@ -5,7 +5,7 @@
 include '../ecobricks_env.php';
 
 
-$trainingId = $_GET['training_id'];
+$trainingId = isset($_GET['training_id']) ? $_GET['training_id'] : (isset($_GET['id']) ? $_GET['id'] : 0);
 
 $sql = "SELECT * FROM tb_trainings WHERE training_id = '" . $trainingId . "'";
 

--- a/meta/training-fr.php
+++ b/meta/training-fr.php
@@ -5,7 +5,7 @@
 include '../ecobricks_env.php';
 
 
-$trainingId = $_GET['training_id'];
+$trainingId = isset($_GET['training_id']) ? $_GET['training_id'] : (isset($_GET['id']) ? $_GET['id'] : 0);
 
 $sql = "SELECT * FROM tb_trainings WHERE training_id = '" . $trainingId . "'";
 

--- a/meta/training-id.php
+++ b/meta/training-id.php
@@ -5,7 +5,7 @@
 include '../ecobricks_env.php';
 
 
-$trainingId = $_GET['training_id'];
+$trainingId = isset($_GET['training_id']) ? $_GET['training_id'] : (isset($_GET['id']) ? $_GET['id'] : 0);
 
 $sql = "SELECT * FROM tb_trainings WHERE training_id = '" . $trainingId . "'";
 


### PR DESCRIPTION
## Summary
- prevent undefined `training_id` in meta pages across languages
- remove unused Training Agenda block
- allow rich-text fields to show line breaks

## Testing
- `php -l en/training.php`
- `php -l meta/training-en.php`
- `php -l meta/training-es.php`
- `php -l meta/training-fr.php`
- `php -l meta/training-id.php`

------
https://chatgpt.com/codex/tasks/task_e_688607236858832ba09dc606d660b1b8