### PR TITLE
Fix training details page and meta images

### DIFF
--- a/en/training.php
+++ b/en/training.php
@@ -30,6 +30,23 @@ $result = $stmt->get_result();
 if ($result->num_rows > 0) {
     $array = $result->fetch_assoc();
 
+    // Look up the community name using the community_id
+    $communityName = '';
+    if (!empty($array['community_id'])) {
+        $commStmt = $conn->prepare("SELECT community_name FROM communities_tb WHERE community_id = ?");
+        if ($commStmt) {
+            $commStmt->bind_param("i", $array['community_id']);
+            if ($commStmt->execute()) {
+                $commResult = $commStmt->get_result();
+                if ($commResult && $commResult->num_rows > 0) {
+                    $commRow = $commResult->fetch_assoc();
+                    $communityName = $commRow['community_name'];
+                }
+            }
+            $commStmt->close();
+        }
+    }
+
 		echo 
 		'<div class="splash-content-block">
 			<div class="splash-box">
@@ -58,13 +75,13 @@ if ($result->num_rows > 0) {
                     $array["training_type"] . ' <span data-lang-id="111">workshop run in/on </span>' .
                     $array["training_location"] . '<span data-lang-id="112">. The workshop involved </span>' .
                     $array["no_participants"] . '<span data-lang-id="113"> and was run by GEA trainer(s) </span>' .
-                    $array["lead_trainer"] . ' on $array["training_date"] . ' </p>
+                    $array["lead_trainer"] . ' on ' . $array["training_date"] . '</p>
                 </div>
 
-            <p>Topic: $array["training_subtitle"] . ' </p>
-            <p>Date: $array["training_date"] . ' </p>
-            <p>Logged: $array["training_logged"] . ' </p>
-            <p>For: $array["community_id"] . ' </p>
+            <p>Topic: ' . $array["training_subtitle"] . ' </p>
+            <p>Date: ' . $array["training_date"] . ' </p>
+            <p>Logged: ' . $array["training_logged"] . ' </p>
+            <p>For: ' . htmlspecialchars($communityName, ENT_QUOTES, 'UTF-8') . ' </p>
 
 
 

--- a/meta/training-en.php
+++ b/meta/training-en.php
@@ -25,7 +25,7 @@ if ($result->num_rows > 0) {
         echo '<meta property="og:url" content="https://ecobricks.org/'. $lang .'/training.php?training_id='. $array["training_id"] .'">' ;
         echo '<meta property="og:title" content="'. $array["training_title"] .' |  '. $array["no_participants"] .' participants">';
         echo '<meta property="og:description"   content="'. $array["no_participants"] .' have been training in '. $array["training_location"] .' in a '. $array["training_type"] .' GEA training.">';
-        echo '<meta property="og:image" content="https://ecobricks.org/trainings/photos/training-'. $array["training_id"] .'-1.webp?v=2">';
+        echo '<meta property="og:image" content="'. $array["feature_photo1_main"] .'">';
         echo '<meta property="og:image:alt"     content="A photo of our ecobrick training workshop">';
         echo '<meta property="og:locale" content="en_GB" >';
         echo '<meta property="og:type"          content="website">';

--- a/meta/training-es.php
+++ b/meta/training-es.php
@@ -25,7 +25,7 @@ if ($result->num_rows > 0) {
         echo '<meta property="og:url" content="https://ecobricks.org/'. $lang .'/training.php?training_id='. $array["training_id"] .'">' ;
         echo '<meta property="og:title" content="'. $array["training_title"] .' |  '. $array["no_participants"] .' participantes">';
         echo '<meta property="og:description"   content="'. $array["no_participants"] .' han sido capacitados en '. $array["location_full"] .' en una capacitación '. $array["training_type"] .' de la Alianza Global de Ecoladrillos.">';
-        echo '<meta property="og:image" content="https://ecobricks.org/trainings/photos/training-'. $array["training_id"] .'-1.webp?v=2">';
+        echo '<meta property="og:image" content="'. $array["feature_photo1_main"] .'">';
         echo '<meta property="og:image:alt"     content="Una foto de nuestro taller de capacitación de ecoladrillos">';
         echo '<meta property="og:locale" content="es_ES" >';
         echo '<meta property="og:type"          content="sitio web">';

--- a/meta/training-fr.php
+++ b/meta/training-fr.php
@@ -25,7 +25,7 @@ if ($result->num_rows > 0) {
         echo '<meta property="og:url" content="https://ecobricks.org/'. $lang .'/training.php?training_id='. $array["training_id"] .'">' ;
         echo '<meta property="og:title" content="'. $array["training_title"] .' |  '. $array["no_participants"] .' participants">';
         echo '<meta property="og:description"   content="'. $array["no_participants"] .' ont été formés à '. $array["location_full"] .' dans une formation '. $array["training_type"] .' de l\'Alliance Globale d\'Écobriques.">';
-        echo '<meta property="og:image" content="https://ecobricks.org/trainings/photos/training-'. $array["training_id"] .'-1.webp?v=2">';
+        echo '<meta property="og:image" content="'. $array["feature_photo1_main"] .'">';
         echo '<meta property="og:image:alt"     content="Une photo de notre atelier de formation aux écobriques">';
         echo '<meta property="og:locale" content="fr_FR" >';
         echo '<meta property="og:type"          content="site web">';

--- a/meta/training-id.php
+++ b/meta/training-id.php
@@ -25,7 +25,7 @@ if ($result->num_rows > 0) {
         echo '<meta property="og:url" content="https://ecobricks.org/'. $lang .'/training.php?training_id='. $array["training_id"] .'">' ;
         echo '<meta property="og:title" content="'. $array["training_title"] .' |  '. $array["no_participants"] .' peserta">';
         echo '<meta property="og:description"   content="'. $array["no_participants"] .' telah dilatih di '. $array["location_full"] .' dalam pelatihan '. $array["training_type"] .' dari Aliansi Ecobrick Global.">';
-        echo '<meta property="og:image" content="https://ecobricks.org/trainings/photos/training-'. $array["training_id"] .'-1.webp?v=2">';
+        echo '<meta property="og:image" content="'. $array["feature_photo1_main"] .'">';
         echo '<meta property="og:image:alt"     content="Foto lokakarya pelatihan ecobrick kami">';
         echo '<meta property="og:locale" content="id_ID" >';
         echo '<meta property="og:type"          content="situs web">';


### PR DESCRIPTION
## Summary
- fix variable insertions and lookup community name in `en/training.php`
- use the training's `feature_photo1_main` for og:image in training meta pages

## Testing
- `php -l en/training.php`
- `php -l meta/training-en.php`
- `php -l meta/training-es.php`
- `php -l meta/training-fr.php`
- `php -l meta/training-id.php`


------
https://chatgpt.com/codex/tasks/task_e_688614dda104832b87b6e2ba1b087488