### PR TITLE
Fix training date formatting and add Chinese translation

### DIFF
--- a/en/training.php
+++ b/en/training.php
@@ -29,6 +29,7 @@ $result = $stmt->get_result();
 
 if ($result->num_rows > 0) {
     $array = $result->fetch_assoc();
+    $trainingDateFormatted = date("F j, Y", strtotime($array["training_date"]));
 
     // Look up the community name using the community_id via the Buwana API
     $communityName = '';
@@ -57,8 +58,8 @@ if ($result->num_rows > 0) {
 			</div>
 			
 			<div class="splash-image">
-				<a href="javascript:void(0);" onclick="viewGalleryImage(\'' . htmlspecialchars($array["training_photo0_main"], ENT_QUOTES, 'UTF-8') . '\', \'Ecobrick training ' . htmlspecialchars($array["training_id"], ENT_QUOTES, 'UTF-8') . ' was completed in ' . htmlspecialchars($array["training_country"], ENT_QUOTES, 'UTF-8') . ' and started on ' . htmlspecialchars($array["training_date"], ENT_QUOTES, 'UTF-8') . '\')"><img src="https://gobrik.com/' . htmlspecialchars($array["training_photo0_main"], ENT_QUOTES, 'UTF-8') . '" alt="Project ' . htmlspecialchars($array["training_id"], ENT_QUOTES, 'UTF-8') . ' was completed in ' . htmlspecialchars($array["training_location"], ENT_QUOTES, 'UTF-8') . ' and started on ' . htmlspecialchars($array["training_date"], ENT_QUOTES, 'UTF-8') . '"
-			title="Project' . htmlspecialchars($array["training_id"], ENT_QUOTES, 'UTF-8') . ' was made in ' . htmlspecialchars($array["training_country"], ENT_QUOTES, 'UTF-8') . ' and started on ' . htmlspecialchars($array["training_date"], ENT_QUOTES, 'UTF-8') . '"></a>
+				<a href="javascript:void(0);" onclick="viewGalleryImage(\'' . htmlspecialchars($array["training_photo0_main"], ENT_QUOTES, 'UTF-8') . '\', \'Ecobrick training ' . htmlspecialchars($array["training_id"], ENT_QUOTES, 'UTF-8') . ' was completed in ' . htmlspecialchars($array["training_country"], ENT_QUOTES, 'UTF-8') . ' and started on ' . htmlspecialchars($trainingDateFormatted, ENT_QUOTES, 'UTF-8') . '\')"><img src="https://gobrik.com/' . htmlspecialchars($array["training_photo0_main"], ENT_QUOTES, 'UTF-8') . '" alt="Project ' . htmlspecialchars($array["training_id"], ENT_QUOTES, 'UTF-8') . ' was completed in ' . htmlspecialchars($array["training_location"], ENT_QUOTES, 'UTF-8') . ' and started on ' . htmlspecialchars($trainingDateFormatted, ENT_QUOTES, 'UTF-8') . '"
+			title="Project' . htmlspecialchars($array["training_id"], ENT_QUOTES, 'UTF-8') . ' was made in ' . htmlspecialchars($array["training_country"], ENT_QUOTES, 'UTF-8') . ' and started on ' . htmlspecialchars($trainingDateFormatted, ENT_QUOTES, 'UTF-8') . '"></a>
 			</div>    
 		</div>
 	
@@ -75,17 +76,12 @@ if ($result->num_rows > 0) {
                     $array["training_type"] . ' <span data-lang-id="111">workshop run in/on </span>' .
                     $array["training_location"] . '<span data-lang-id="112">. The workshop involved </span>' .
                     $array["no_participants"] . '<span data-lang-id="113"> and was run by GEA trainer(s) </span>' .
-                        $array["lead_trainer"] . ' on <?= $array["training_date"]->format('F j, Y') ?></p>
-                </div>
-
-            <p><b>Topic:</b> ' . $array["training_subtitle"] . ' </p>
-            <p><b>Date:</b> ' . $array["training_date"] . ' </p>
-            <p><b>Community:</b> ' . htmlspecialchars($communityName, ENT_QUOTES, 'UTF-8') . ' </p>
-
-
-
-                <div id="three-column-gal" class="three-column-gal" style="margin-top:40px;">';
-
+                        $array["lead_trainer"] . ' on ' . $trainingDateFormatted . '</p>' .
+                        '</div>' .
+            '<p><b>Topic:</b> ' . $array["training_subtitle"] . ' </p>' .
+            '<p><b>Date:</b> ' . $trainingDateFormatted . ' </p>' .
+            '<p><b>Community:</b> ' . htmlspecialchars($communityName, ENT_QUOTES, 'UTF-8') . ' </p>' .
+            '<div id="three-column-gal" class="three-column-gal" style="margin-top:40px;">';
 // Loop through the available photos (up to 6)
 for ($i = 0; $i <= 6; $i++) {
     $photo_main_field = "training_photo" . $i . "_main";

--- a/meta/training-zh.php
+++ b/meta/training-zh.php
@@ -1,0 +1,46 @@
+<?php
+
+include '../ecobricks_env.php';
+
+$trainingId = isset($_GET['training_id']) ? $_GET['training_id'] : (isset($_GET['id']) ? $_GET['id'] : 0);
+
+$sql = "SELECT * FROM tb_trainings WHERE training_id = '" . $trainingId . "'";
+
+$result = $conn->query($sql);
+if ($result->num_rows > 0) {
+
+    while($array = $result->fetch_assoc()) {
+
+        echo '<title>'. $array["training_title"] .' |  '. $array["no_participants"] .' 参与者</title>';
+
+        echo '<meta name="description" content="'. $array["no_participants"] .' 位参与者在 '. $array["location_full"] .' 参加了 '. $array["training_type"] .' 培训。">';
+
+        echo '<meta name="keywords" content="培训, 工作坊, 塑料教育, ecobrick, '. $array["lead_trainer"] .', '. $array["training_type"] .', 塑料封存, 回收, 替代方案, 生态砖, '. $array["training_country"] .','. $array["training_location"] .'">';
+
+        echo '<meta property="og:url" content="https://ecobricks.org/'. $lang .'/training.php?training_id='. $array["training_id"] .'">' ;
+        echo '<meta property="og:title" content="'. $array["training_title"] .' |  '. $array["no_participants"] .' 参与者">';
+        echo '<meta property="og:description"   content="'. $array["no_participants"] .' 位参与者在 '. $array["location_full"] .' 参加了 '. $array["training_type"] .' 培训。">';
+        echo '<meta property="og:image" content="'. $array["feature_photo1_main"] .'">';
+        echo '<meta property="og:image:alt"     content="我们的生态砖培训照片">';
+        echo '<meta property="og:locale" content="zh_CN" >';
+        echo '<meta property="og:type"          content="website">';
+
+        echo '<meta property="og:type" content="article" >';
+        echo '<meta property="og:site_name" content="Ecobricks.org" >';
+        echo '<meta property="article:publisher" content="https://web.facebook.com/ecobricks.org" >';
+        echo '<meta property="article:modified_time" content="'. $array["training_logged"] .'" >';
+        echo '<meta property="og:image:type" content="image/webp" >';
+        echo '<meta name="author" content="全球生态砖联盟" >';
+        echo '<meta name="twitter:card" content="summary" >';
+        echo '<meta name="twitter:label1" content="预计阅读时间" >';
+        echo '<meta name="twitter:data1" content="15分钟" > ';
+    }
+
+} else {
+    echo '<META NAME="robots" CONTENT="noindex">';
+    echo '<title>未找到培训 | Ecobricks.org</title>';
+    echo '<meta name="description" content="未找到对应培训 ID 的数据。 可能链接错误或培训尚未完全记录。"> ';
+}
+$conn->close();
+
+?>

--- a/translations/training-zh.js
+++ b/translations/training-zh.js
@@ -1,0 +1,9 @@
+/*-----------------------------------
+
+ SNIPPETS FOR Training Details page on ECOBRICKS.ORG
+
+-----------------------------------*/
+
+const zh_Page_Translations = {
+
+};


### PR DESCRIPTION
## Summary
- format training date without time on the training details page
- add Chinese meta page for training details
- add placeholder Chinese translation file

## Testing
- `php -l en/training.php`
- `php -l meta/training-zh.php`

------
https://chatgpt.com/codex/tasks/task_e_6886265f60e4832ba2055889790439af