### PR TITLE
Enable dark mode toggle and center search overlay

### DIFF
--- a/css/stylesheet-2025.css
+++ b/css/stylesheet-2025.css
@@ -732,21 +732,21 @@ legend {
     top: 0;
     overflow-x: hidden; /* Disable horizontal scroll */
     transition: 0.5s; /* 0.5 second transition effect to slide in or slide down the overlay (height or width, depending on reveal) */
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 
 /* Position the content inside the overlay */
 .search-overlay-content {
-    position: initial;
     text-align: center; /* Centered text/links */
-    /*margin-top: 30px; 30px top margin to avoid conflict with the close button on smaller screens */
     font-family: "CooperLT";
     display: flex;
-    justify-content: center;
-    flex-flow: column;
-    height:fit-content;
+    flex-direction: column;
+    align-items: center;
+    height: fit-content;
     margin: auto;
-    transition: margin-top 0.5s ease-in-out;
 }
 
 
@@ -754,8 +754,6 @@ legend {
     .search-overlay-content {
         width: 92%;
         font-size: 0.9em;
-        /*margin-top: 6%;*/
-        margin-top: 30%;
     }
 }
 
@@ -763,8 +761,6 @@ legend {
     .search-overlay-content {
         width: 75%;
         font-size: 0.9em;
-        /*margin-top: 2%;*/
-        margin-top:30%;
     }
 }
 
@@ -772,7 +768,6 @@ legend {
     .search-overlay-content {
         width: 72%;
         margin: auto;
-        margin-top:14%;
     }
 }
 

--- a/header-2025.php
+++ b/header-2025.php
@@ -69,8 +69,8 @@
 <script src="../js/core-scripts-2025.js?v=3<?php echo ($version); ;?>"></script>
 <script src="../js/language-switcher.js?v=3<?php echo ($version); ;?>3"></script>
 
-<!--This enables the Light and Dark mode switching
-<script type="module" src="../mode-toggle.mjs.js?v=<?php echo ($version); ;?>"></script>-->
+<!--This enables the Light and Dark mode switching-->
+<script type="module" src="../mode-toggle.mjs.js?v=<?php echo ($version); ;?>"></script>
 
 <script src="../js/guided-tour.js?v=2<?php echo ($version); ;?>" defer></script>
 

--- a/js/site-search.js
+++ b/js/site-search.js
@@ -119,7 +119,6 @@ function siteSearch() {
 
     var overlayContent = document.querySelector('.search-overlay-content');
     overlayContent.style.height = 'fit-content';
-    overlayContent.style.marginTop = '8%';
 
     var posts = [];
     var numFilesLoaded = 0;


### PR DESCRIPTION
## Summary
- Enable dark mode switch script so toggle renders
- Center search overlay content via flex layout and remove margin hacks
- Simplify search overlay JS to rely on CSS centering

## Testing
- `php -l header-2025.php`
- `node --check js/site-search.js`
- `npx stylelint css/stylesheet-2025.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_68a47438464c832ba2ac25f3cf27fa90