### PR TITLE
Fix homepage slider spacing and update event details

### DIFF
--- a/en/index.php
+++ b/en/index.php
@@ -24,12 +24,12 @@ include '../ecobricks_env.php';
                     <div class="featured-content-text">
                         <div class="featured-content-title" data-lang-id="300-featured-content-1-title">Intro to Ecobricks Event</div>
                         <div class="featured-content-subtitle" data-lang-id="301-featured-content-1-subtitle">Join us for a live and free introductory course.  Learn the science, philosophy and essential techniques in our live community event 'Plastic, the Biosphere & Ecobricks'.  Zoom. Free.</div>
-                        <a class="content-button" href="https://gobrik.com/en/courses.php" data-lang-id="302-featured-content-1-button">↗️ Sept. 21 Event</a>
+                        <a class="content-button" href="https://gobrik.com/en/courses.php" data-lang-id="302-featured-content-1-button">↗️ Oct. 5 Event</a>
                     </div>
                 </div>
            </div>
 
-            <div id="slider-content-2" class="slider-slide" >
+            <!-- <div id="slider-content-2" class="slider-slide" >
             <div class="featured-content-shaded-box">
                 <div class="featured-content-text">
                     <div class="featured-content-title" data-lang-id="300-featured-content-2-title">What should green really mean?</div>
@@ -38,7 +38,7 @@ include '../ecobricks_env.php';
                     <a class="content-button" href="https://gobrik.com/en/courses.php" data-lang-id="302-featured-content-2-button">↗️ August 30th Event</a>
                 </div>
             </div>
-       </div>
+       </div> -->
 
             <div id="slider-content-3" class="slider-slide" >
                 <div class="featured-content-shaded-box">
@@ -145,7 +145,7 @@ include '../ecobricks_env.php';
         <div class="gallery-flex-container">
         <?php
     // Updated SQL query to include a WHERE clause and a LIMIT
-    $sql = "SELECT * FROM tb_projects WHERE ready_to_show = 1 ORDER BY project_id DESC LIMIT 20;";
+    $sql = "SELECT * FROM tb_projects WHERE ready_to_show = 1 ORDER BY project_id DESC LIMIT 12;";
     $result = $conn->query($sql);
 
     if ($result->num_rows > 0) {
@@ -191,7 +191,7 @@ include '../ecobricks_env.php';
     <div class="gallery-flex-container">
         <?php
         // Updated SQL query to include a WHERE clause and a LIMIT
-        $sql = "SELECT * FROM tb_trainings WHERE ready_to_show = 1 AND show_report = 1 ORDER BY training_id DESC LIMIT 20;";
+        $sql = "SELECT * FROM tb_trainings WHERE ready_to_show = 1 AND show_report = 1 ORDER BY training_id DESC LIMIT 12;";
         $result = $conn->query($sql);
 
         if ($result->num_rows > 0) {

--- a/includes/index-inc.php
+++ b/includes/index-inc.php
@@ -20,10 +20,11 @@
 .feature-content-anchor-box{
 width: 100%;
   margin-top: 0px;
-  padding-top: 90px;
+  padding: 90px 22px 0;
   overflow: clip;
   display: flex;
   flex-flow: column;
+  box-sizing: border-box;
 }
 
 .slider-slide {
@@ -38,8 +39,6 @@ width: 100%;
   position: relative;
   overflow: hidden;
   margin-bottom: 13vh;
-  margin-right: 22px;
-  margin-left: 22px;
   border-radius: 20px;
   max-width: 100%;
 
@@ -59,8 +58,6 @@ width: 100%;
     position: relative;
     overflow: hidden;
     margin-bottom: 9vh;
-    margin-right: 16px;
-    margin-left: 16px;
     border-radius: 18px;
     max-width: 100%;
     margin-top: -5px;
@@ -137,6 +134,8 @@ width: 100%;
   .feature-content-anchor-box{
     height:92vh;
     max-height: 92vh;
+    padding-left: 16px;
+    padding-right: 16px;
   }
 
   #slider-content-1 {

--- a/translations/index-en.js
+++ b/translations/index-en.js
@@ -3,7 +3,7 @@
 const en_Page_Translations = {
   "300-featured-content-1-title": "Intro to Ecobricks Event",
   "301-featured-content-1-subtitle": "Join us for a live and free introductory course.  Learn the science, philosophy and essential techniques in our live community event 'Plastic, the Biosphere & Ecobricks'.  Zoom. Free.",
-  "302-featured-content-1-button": "↗️ Sept. 21 Event",
+  "302-featured-content-1-button": "↗️ Oct. 5 Event",
   "300-featured-content-2-title": "What should green really mean?",
   "301-featured-content-2-subtitle": "Ecobricking is guided by the indigenous concept of Ayyew.  This ecological ethos inspires our Earthen ethics, our ecobricking and our understanding of Green.",
   "302-featured-content-2-button": "↗️ August 30th Event",

--- a/translations/index-es.js
+++ b/translations/index-es.js
@@ -6,7 +6,7 @@ const es_Page_Translations = {
 
     "300-featured-content-1-title": "Evento de Introducción a los Ecobricks",
     "301-featured-content-1-subtitle": "Únase a nosotros para un curso introductorio en vivo y gratuito. Aprenda la ciencia, la filosofía y las técnicas esenciales en nuestro evento comunitario en vivo 'Plástico, la Biosfera y los Ecobricks'. Zoom. Gratis.",
-    "302-featured-content-1-button": "↗️ Evento 21 de Sept.",
+    "302-featured-content-1-button": "↗️ Evento 5 de Oct.",
     "300-featured-content-2-title": "¿Qué debería significar realmente verde?",
     "301-featured-content-2-subtitle": "El ecobricking está guiado por el concepto indígena de Ayyew. Este ethos ecológico inspira nuestra ética terrenal, nuestro ecobricking y nuestra comprensión de lo Verde.",
     "302-featured-content-2-button": "↗️ Evento 30 de Agosto",

--- a/translations/index-fr.js
+++ b/translations/index-fr.js
@@ -2,7 +2,7 @@
 const fr_Page_Translations = {
   "300-featured-content-1-title": "Événement d'introduction aux écobriques",
   "301-featured-content-1-subtitle": "Rejoignez-nous pour un cours introductif en direct et gratuit. Apprenez la science, la philosophie et les techniques essentielles lors de notre événement communautaire en direct 'Plastique, la biosphère et les écobriques'. Zoom. Gratuit.",
-  "302-featured-content-1-button": "↗️ Événement du 21 sept.",
+  "302-featured-content-1-button": "↗️ Événement du 5 oct.",
   "300-featured-content-2-title": "Que devrait vraiment signifier le vert ?",
   "301-featured-content-2-subtitle": "L'écobriquage est guidé par le concept indigène d'Ayyew. Cet ethos écologique inspire notre éthique terrestre, notre écobriquage et notre compréhension du Vert.",
   "302-featured-content-2-button": "↗️ Événement du 30 août",

--- a/translations/index-id.js
+++ b/translations/index-id.js
@@ -3,7 +3,7 @@
 const id_Page_Translations = {
   "300-featured-content-1-title": "Acara Pengantar Ecobrick",
   "301-featured-content-1-subtitle": "Bergabunglah dengan kami dalam kursus pengantar langsung dan gratis. Pelajari ilmu, filosofi, dan teknik penting dalam acara komunitas kami 'Plastik, Biosfer & Ecobrick'. Zoom. Gratis.",
-  "302-featured-content-1-button": "↗️ Acara 21 Sept.",
+  "302-featured-content-1-button": "↗️ Acara 5 Okt.",
   "300-featured-content-2-title": "Apa arti hijau yang sebenarnya?",
   "301-featured-content-2-subtitle": "Ecobricking dipandu oleh konsep adat Ayyew. Etos ekologis ini menginspirasi etika Earthen kami, ecobricking kami, dan pemahaman kami tentang Hijau.",
   "302-featured-content-2-button": "↗️ Acara 30 Agustus",

--- a/translations/index-zh.js
+++ b/translations/index-zh.js
@@ -7,7 +7,7 @@ CHINESE TRANSLATION FOR ECOBRICKS.ORG
 const zh_Page_Translations = {
     "300-featured-content-1-title": "生态砖介绍活动",
     "301-featured-content-1-subtitle": "加入我们的免费直播入门课程。在我们的社区活动‘塑料、生物圈与生态砖’中学习科学、哲学和关键技巧。Zoom。免费。",
-    "302-featured-content-1-button": "↗️ 9月21日活动",
+    "302-featured-content-1-button": "↗️ 10月5日活动",
   "300-featured-content-2-title": "“绿色”究竟应该意味着什么？",
   "301-featured-content-2-subtitle": "生态砖实践受到本土理念 Ayyew 的指引。这种生态精神启发了我们的土伦理、生态砖制作以及我们对绿色的理解。",
   "302-featured-content-2-button": "↗️ 8月30日活动",


### PR DESCRIPTION
## Summary
- adjust the homepage slider container padding so featured content keeps even margins
- refresh the featured event button to reference the October 5 session in all supported translations and hide the second slide
- limit the featured project and training galleries to the 12 most recent entries

## Testing
- php -l en/index.php


------
https://chatgpt.com/codex/tasks/task_e_68d7a596f12c832bbd8b16372f202677