### PR TITLE
Update slider event date and main menu options

### DIFF
--- a/en/index.php
+++ b/en/index.php
@@ -24,7 +24,7 @@ include '../ecobricks_env.php';
                     <div class="featured-content-text">
                         <div class="featured-content-title" data-lang-id="300-featured-content-1-title">Intro to Ecobricks Event</div>
                         <div class="featured-content-subtitle" data-lang-id="301-featured-content-1-subtitle">Join us for a live and free introductory course.  Learn the science, philosophy and essential techniques in our live community event 'Plastic, the Biosphere & Ecobricks'.  Zoom. Free.</div>
-                        <a class="content-button" href="https://gobrik.com/en/courses.php" data-lang-id="302-featured-content-1-button">↗️ Oct. 20 Event</a>
+                        <a class="content-button" href="https://gobrik.com/en/courses.php" data-lang-id="302-featured-content-1-button">↗️ Sunday, Oct. 19 Event</a>
                     </div>
                 </div>
            </div>

--- a/header-2025.php
+++ b/header-2025.php
@@ -598,14 +598,6 @@ display: none;
         </div>
 
 
-        <div class="submenu-item-container">
-            <div class="submenu-item" >
-                <a href="media.php">Press Kit</a>
-                <span class="circle" title="This page is 100% translated to English but in our non-git format.   Queued for migration." style="color:orange">●</span>
-            </div>
-            <div class="translation-info" data-lang-id="005-menu-1-trans-text-3">🏴󠁧󠁢󠁥󠁮󠁧󠁿 media.php has been translated 100%</div>
-        </div>
-
     </div>
 </div>
 
@@ -645,6 +637,14 @@ display: none;
         <span class="circle" title="This page has been 100% translated to English" style="color:green;  ">●</span>
       </div>
       <div class="translation-info" data-lang-id="013-menu-2-trans-text-3">earth.php has been translated 75% | <a href="https://github.com/gea-ecobricks/ecobricks-org/blob/main/translations/earth-fr-translation.js" class="translate-link">help edit ⇗</a></div>
+    </div>
+
+    <div class="submenu-item-container">
+      <div class="submenu-item" data-lang-id="022-menu-2-sub-item-8">
+        <a href="ecojoiners.php">Ecojoiners</a>
+        <span class="circle" title="This page has been 100% translated to English" style="color:green;  ">●</span>
+      </div>
+      <div class="translation-info" data-lang-id="023-menu-2-trans-text-8">🏴 ecojoiners.php has been translated 100% | <a href="https://github.com/gea-ecobricks/ecobricks-org/blob/main/en/ecojoiners.php" class="translate-link">code ⇗</a></div>
     </div>
 
     <!-- <div class="submenu-item-container">
@@ -836,6 +836,14 @@ display: none;
   </div>
   <div class="translation-info" data-lang-id="060-menu-5-trans-text-9">🏴󠁧󠁢󠁥󠁮󠁧󠁿  /movement is 100% in English however is in our non-git system | queued for transition</div>
 </div>
+<div class="submenu-item-container">
+  <div class="submenu-item">
+      <a href="media.php">Press Kit</a>
+      <span class="circle" title="This page is 100% translated to English but in our non-git format.   Queued for migration." style="color:orange">●</span>
+  </div>
+  <div class="translation-info" data-lang-id="005-menu-1-trans-text-3">🏴 media.php has been translated 100%</div>
+</div>
+
 
 </div>
 </div>

--- a/menu-bar.php
+++ b/menu-bar.php
@@ -85,6 +85,7 @@
                     <a href="build.php">Building Methods</a>
                     <a href="/modules">Lego Modules</a>
                     <a href="/earth">Earth & Ecobricks</a>
+                    <a href="ecojoiners.php">Ecojoiners</a>
                     <a href="/openspaces">Open Spaces</a>
                 </div>
             </div>

--- a/menus/menu-en.php
+++ b/menus/menu-en.php
@@ -95,6 +95,7 @@
                     <a href="build.php">Building Methods</a>
                     <a href="modules.php">Ecobrick Modules</a>
                     <a href="earth.php?v2">Earth & Ecobricks</a>
+                    <a href="ecojoiners.php">Ecojoiners</a>
                     <a href="/openspace/">Open Spaces</a>
                 </div>
             </div>

--- a/menus/menu-es.php
+++ b/menus/menu-es.php
@@ -96,6 +96,7 @@
                  <a href="build.php">Métodos</a>
                  <a href="/modules">Módulos</a>
                  <a href="/earth">Tierra & Ecobricks</a>
+                 <a href="ecojoiners.php">Ecojoiners</a>
                  <a href="/openspaces">Open Spaces</a>
                  <a href="brickable.php">Diseño Brickable</a>
              </div>

--- a/menus/menu-fr.php
+++ b/menus/menu-fr.php
@@ -78,6 +78,7 @@
                     <a href="build.php">Méthodes de construction</a>
                     <a href="/modules">Lego Modules</a>
                     <a href="/earth">Terre & Ecobricks</a>
+                    <a href="ecojoiners.php">Ecojoiners</a>
                     <a href="/openspaces">Open Spaces</a>
                 </div>
             </div>

--- a/menus/menu-id.php
+++ b/menus/menu-id.php
@@ -96,6 +96,7 @@
                     <a href="build.php">Metode</a>
                     <a href="/modules">Genis Modul</a>
                     <a href="/earth">Tanah dan Ecobrick</a>
+                    <a href="ecojoiners.php">Ecojoiners</a>
                     <a href="/openspaces">Open Spaces</a>
                 </div>
             </div>

--- a/menus/menu-id2.php
+++ b/menus/menu-id2.php
@@ -96,6 +96,7 @@
                     <a href="build.php">Metode</a>
                     <a href="/modules">Genis Modul</a>
                     <a href="/earth">Tanah dan Ecobrick</a>
+                    <a href="ecojoiners.php">Ecojoiners</a>
                     <a href="/openspaces">Open Spaces</a>
                 </div>
             </div>

--- a/menus/menu-vi.php
+++ b/menus/menu-vi.php
@@ -96,6 +96,7 @@
                     <a href="build.php">Building Methods</a>
                     <a href="/modules">Lego Modules</a>
                     <a href="/earth">Earth & Ecobricks</a>
+                    <a href="ecojoiners.php">Ecojoiners</a>
                     <a href="/openspaces">Open Spaces</a>
                 </div>
             </div>

--- a/translations/core-texts-en.js
+++ b/translations/core-texts-en.js
@@ -55,6 +55,8 @@ const en_Translations = {
       "021-menu-2-trans-text-7": "🏴 /earth-methods has been translated 100% | migration to new git site pending",
       "012-menu-2-sub-item-3": '<a href="earth.php">Earth Building</a><span class="circle" title="This page has been 100% translated to English" style="color:green;  ">●</span>',
       "013-menu-2-trans-text-3": "earth.php has been translated 75% | <a href=\"https://github.com/gea-ecobricks/ecobricks-org/blob/main/translations/earth-fr-translation.js\" class=\"translate-link\">help edit ⇗</a>",
+      "022-menu-2-sub-item-8": '<a href="ecojoiners.php">Ecojoiners</a><span class="circle" title="This page has been 100% translated to English" style="color:green;  ">●</span>',
+      "023-menu-2-trans-text-8": "🏴 ecojoiners.php has been translated 100% | <a href=\"https://github.com/gea-ecobricks/ecobricks-org/blob/main/en/ecojoiners.php\" class=\"translate-link\">code ⇗</a>",
       "014-menu-2-sub-item-4": '<a href="/earth-methods">Earth Building Methods</a><span class="circle" title="This page is 100% translated to English but in our non-git format.   Queued for migration." style="color:orange">●</span>',
       "015-menu-2-trans-text-4": "🏴 /earth-methods has been translated 100% | migration to new git site pending",
       "018-menu-2-sub-item-6": '<a href="/openspace">Open spaces</a><span class="circle" title="This page is 100% translated to English but in our non-git format.   Queued for migration." style="color:orange">●</span>',

--- a/translations/core-texts-es.js
+++ b/translations/core-texts-es.js
@@ -54,7 +54,10 @@ const es_Translations = {
     "021-menu-2-trans-text-7": "🇪🇸 /earth-methods ha sido traducido al 0% | migración al nuevo sitio git en espera",
     "012-menu-2-sub-item-3": '<a href="earth.php">Construcción Terrestre</a><span class="circle" title="Esta página ha sido traducida al 15%" style="color:yellow;  ">●</span>',
     "013-menu-2-trans-text-3": "earth.php ha sido traducido al 15% | <a href=\"https://github.com/gea-ecobricks/ecobricks-org/blob/main/translations/earth-es-translation.js\" class=\"translate-link\">ayuda a editar ⇗</a>",
-    
+
+    "022-menu-2-sub-item-8": '<a href="ecojoiners.php">Ecojoiners</a><span class="circle" title="Esta página está disponible en inglés" style="color:green;  ">●</span>',
+    "023-menu-2-trans-text-8": "🇪🇸 ecojoiners.php está disponible en inglés | <a href=\"https://github.com/gea-ecobricks/ecobricks-org/blob/main/en/ecojoiners.php\" class=\"translate-link\">código ⇗</a>",
+
     "014-menu-2-sub-item-4": '<a href="/earth-methods">Métodos de Construcción Terrestre</a><span class="circle" title="Esta página ha sido traducida al 0% y está en nuestro formato no-git.   En espera de migración." style="color:red">●</span>',
     "015-menu-2-trans-text-4": "🇪🇸 /earth-methods ha sido traducido al 0% | migración al nuevo sitio git en espera",
     "018-menu-2-sub-item-6": '<a href="/openspace">Espacios Abiertos</a><span class="circle" title="Esta página ha sido traducida al 100% en inglés pero está en nuestro formato no-git.   En espera de migración." style="color:red">●</span>',

--- a/translations/core-texts-fr.js
+++ b/translations/core-texts-fr.js
@@ -55,6 +55,9 @@ const fr_Translations = {
     "012-menu-2-sub-item-3": '<a href="earth.php">Construction Terrestre</a><span class="circle" title="Cette page a été traduite à 15%" style="color:yellow;  ">●</span>',
     "013-menu-2-trans-text-3": "earth.php a été traduit à 15% | <a href=\"https://github.com/gea-ecobricks/ecobricks-org/blob/main/translations/earth-fr-translation.js\" class=\"translate-link\">aidez à éditer ⇗</a>",
 
+    "022-menu-2-sub-item-8": '<a href="ecojoiners.php">Ecojoiners</a><span class="circle" title="Cette page est disponible en anglais" style="color:green;  ">●</span>',
+    "023-menu-2-trans-text-8": "🇫🇷 ecojoiners.php est disponible en anglais | <a href=\"https://github.com/gea-ecobricks/ecobricks-org/blob/main/en/ecojoiners.php\" class=\"translate-link\">code ⇗</a>",
+
     "014-menu-2-sub-item-4": '<a href="/earth-methods">Méthodes de Construction Terrestre</a><span class="circle" title="Cette page a été traduite à 0% et est dans notre format non-git.   En attente de migration." style="color:red">●</span>',
     "015-menu-2-trans-text-4": "🏴 /earth-methods a été traduit à 0% | migration vers le nouveau site git en attente",
     "018-menu-2-sub-item-6": '<a href="/openspace">Espaces Ouverts</a><span class="circle" title="Cette page a été traduite à 100% en anglais mais dans notre format non-git.   En attente de migration." style="color:red">●</span>',

--- a/translations/core-texts-id.js
+++ b/translations/core-texts-id.js
@@ -50,6 +50,9 @@ const id_Translations = {
 "012-menu-2-sub-item-3": '<a href="earth.php">Konstruksi Bumi</a><span class="circle" title="Halaman ini telah diterjemahkan 15%" style="color:yellow;  ">●</span>',
 "013-menu-2-trans-text-3": "earth.php telah diterjemahkan 15% | <a href=\"https://github.com/gea-ecobricks/ecobricks-org/blob/main/translations/earth-fr-translation.js\" class=\"translate-link\">bantu edit ⇗</a>",
 
+"022-menu-2-sub-item-8": '<a href="ecojoiners.php">Ecojoiners</a><span class="circle" title="Halaman ini tersedia dalam bahasa Inggris" style="color:green;  ">●</span>',
+"023-menu-2-trans-text-8": "🇮🇩 ecojoiners.php tersedia dalam bahasa Inggris | <a href=\"https://github.com/gea-ecobricks/ecobricks-org/blob/main/en/ecojoiners.php\" class=\"translate-link\">kode ⇗</a>",
+
 "014-menu-2-sub-item-4": '<a href="/earth-methods">Metode Konstruksi Bumi</a><span class="circle" title="Halaman ini telah diterjemahkan 0% dan sedang menunggu migrasi." style="color:red">●</span>',
 "015-menu-2-trans-text-4": "🏴 /earth-methods telah diterjemahkan 0% | menunggu migrasi ke situs git baru",
 "018-menu-2-sub-item-6": '<a href="/openspace">Ruang Terbuka</a><span class="circle" title="Halaman ini telah diterjemahkan 100% dalam bahasa Inggris tetapi sedang menunggu migrasi." style="color:red">●</span>',

--- a/translations/core-texts-zh.js
+++ b/translations/core-texts-zh.js
@@ -31,6 +31,8 @@ const zh_Translations = {
     "021-menu-2-trans-text-7": "🏴 /earth-methods 已翻译完成 100% | 等待迁移到新 Git 网站",
     "012-menu-2-sub-item-3": '<a href="earth.php">土筑建造</a><span class="circle" title="本页面已100%翻译为中文" style="color:green;  ">●</span>',
     "013-menu-2-trans-text-3": "earth.php 已翻译 75% | <a href=\"https://github.com/gea-ecobricks/ecobricks-org/blob/main/translations/earth-fr-translation.js\" class=\"translate-link\">协助编辑 ⇗</a>",
+    "022-menu-2-sub-item-8": '<a href="ecojoiners.php">Ecojoiners</a><span class="circle" title="本页面提供英文内容" style="color:green;  ">●</span>',
+    "023-menu-2-trans-text-8": "🇨🇳 ecojoiners.php 目前提供英文内容 | <a href=\"https://github.com/gea-ecobricks/ecobricks-org/blob/main/en/ecojoiners.php\" class=\"translate-link\">代码 ⇗</a>",
     "014-menu-2-sub-item-4": '<a href="/earth-methods">土筑建造方法</a><span class="circle" title="本页面已100%翻译为中文，但使用旧格式。等待迁移。" style="color:orange">●</span>',
     "015-menu-2-trans-text-4": "🏴 /earth-methods 已翻译完成 100% | 等待迁移到新 Git 网站",
     "018-menu-2-sub-item-6": '<a href="/openspace">开放空间</a><span class="circle" title="本页面已100%翻译为中文，但使用旧格式。等待迁移。" style="color:orange">●</span>',

--- a/translations/index-en.js
+++ b/translations/index-en.js
@@ -3,7 +3,7 @@
 const en_Page_Translations = {
   "300-featured-content-1-title": "Intro to Ecobricks Event",
   "301-featured-content-1-subtitle": "Join us for a live and free introductory course.  Learn the science, philosophy and essential techniques in our live community event 'Plastic, the Biosphere & Ecobricks'.  Zoom. Free.",
-  "302-featured-content-1-button": "↗️ Oct. 20 Event",
+  "302-featured-content-1-button": "↗️ Sunday, Oct. 19 Event",
   "300-featured-content-2-title": "What should green really mean?",
   "301-featured-content-2-subtitle": "Ecobricking is guided by the indigenous concept of Ayyew.  This ecological ethos inspires our Earthen ethics, our ecobricking and our understanding of Green.",
   "302-featured-content-2-button": "↗️ August 30th Event",

--- a/translations/index-es.js
+++ b/translations/index-es.js
@@ -6,7 +6,7 @@ const es_Page_Translations = {
 
     "300-featured-content-1-title": "Evento de Introducción a los Ecobricks",
     "301-featured-content-1-subtitle": "Únase a nosotros para un curso introductorio en vivo y gratuito. Aprenda la ciencia, la filosofía y las técnicas esenciales en nuestro evento comunitario en vivo 'Plástico, la Biosfera y los Ecobricks'. Zoom. Gratis.",
-    "302-featured-content-1-button": "↗️ Evento 20 de Oct.",
+    "302-featured-content-1-button": "↗️ Evento Domingo 19 de Oct.",
     "300-featured-content-2-title": "¿Qué debería significar realmente verde?",
     "301-featured-content-2-subtitle": "El ecobricking está guiado por el concepto indígena de Ayyew. Este ethos ecológico inspira nuestra ética terrenal, nuestro ecobricking y nuestra comprensión de lo Verde.",
     "302-featured-content-2-button": "↗️ Evento 30 de Agosto",

--- a/translations/index-fr.js
+++ b/translations/index-fr.js
@@ -2,7 +2,7 @@
 const fr_Page_Translations = {
   "300-featured-content-1-title": "Événement d'introduction aux écobriques",
   "301-featured-content-1-subtitle": "Rejoignez-nous pour un cours introductif en direct et gratuit. Apprenez la science, la philosophie et les techniques essentielles lors de notre événement communautaire en direct 'Plastique, la biosphère et les écobriques'. Zoom. Gratuit.",
-  "302-featured-content-1-button": "↗️ Événement du 20 oct.",
+  "302-featured-content-1-button": "↗️ Événement du dim. 19 oct.",
   "300-featured-content-2-title": "Que devrait vraiment signifier le vert ?",
   "301-featured-content-2-subtitle": "L'écobriquage est guidé par le concept indigène d'Ayyew. Cet ethos écologique inspire notre éthique terrestre, notre écobriquage et notre compréhension du Vert.",
   "302-featured-content-2-button": "↗️ Événement du 30 août",

--- a/translations/index-id.js
+++ b/translations/index-id.js
@@ -3,7 +3,7 @@
 const id_Page_Translations = {
   "300-featured-content-1-title": "Acara Pengantar Ecobrick",
   "301-featured-content-1-subtitle": "Bergabunglah dengan kami dalam kursus pengantar langsung dan gratis. Pelajari ilmu, filosofi, dan teknik penting dalam acara komunitas kami 'Plastik, Biosfer & Ecobrick'. Zoom. Gratis.",
-  "302-featured-content-1-button": "↗️ Acara 20 Okt.",
+  "302-featured-content-1-button": "↗️ Acara Minggu 19 Okt.",
   "300-featured-content-2-title": "Apa arti hijau yang sebenarnya?",
   "301-featured-content-2-subtitle": "Ecobricking dipandu oleh konsep adat Ayyew. Etos ekologis ini menginspirasi etika Earthen kami, ecobricking kami, dan pemahaman kami tentang Hijau.",
   "302-featured-content-2-button": "↗️ Acara 30 Agustus",

--- a/translations/index-zh.js
+++ b/translations/index-zh.js
@@ -7,7 +7,7 @@ CHINESE TRANSLATION FOR ECOBRICKS.ORG
 const zh_Page_Translations = {
     "300-featured-content-1-title": "生态砖介绍活动",
     "301-featured-content-1-subtitle": "加入我们的免费直播入门课程。在我们的社区活动‘塑料、生物圈与生态砖’中学习科学、哲学和关键技巧。Zoom。免费。",
-    "302-featured-content-1-button": "↗️ 10月20日活动",
+    "302-featured-content-1-button": "↗️ 10月19日（周日）活动",
   "300-featured-content-2-title": "“绿色”究竟应该意味着什么？",
   "301-featured-content-2-subtitle": "生态砖实践受到本土理念 Ayyew 的指引。这种生态精神启发了我们的土伦理、生态砖制作以及我们对绿色的理解。",
   "302-featured-content-2-button": "↗️ 8月30日活动",


### PR DESCRIPTION
## Summary
- update the home page slider button to reference the Sunday, Oct. 19 event and refresh all related translations
- add the Ecojoiners link to the Build menus across language variants and relocate the Press Kit entry under the Global Ecobrick Alliance section

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e75775bef4832bbf95491193b03630