### PR TITLE
Handle null aggregation values and improve brikchain styling

### DIFF
--- a/en/brikchain.php
+++ b/en/brikchain.php
@@ -94,15 +94,23 @@ try {
     $sum_costs = 0;
     $row_count = 0;
 
+    $normalizeValue = static function ($value) {
+        if ($value === null || $value === '') {
+            return 0.0;
+        }
+
+        return (float)str_replace(',', '', (string)$value);
+    };
+
     // Aggregate data
     while ($row = $result->fetch_assoc()) {
         // Normalize values by removing commas and converting to float
-        $sum_ecobricks += (float)str_replace(',', '', $row['brick_count']);
-        $sum_brikcoins += (float)str_replace(',', '', $row['total_brk']);
-        $sum_weight += (float)str_replace(',', '', $row['weight']);
-        $sum_expenses += (float)str_replace(',', '', $row['tot_idr_exp_amt']);
-        $sum_revenue += (float)str_replace(',', '', $row['tot_idr_rev_amt']);
-        $sum_costs += (float)str_replace(',', '', $row['final_aes_plastic_cost_idr']);
+        $sum_ecobricks += $normalizeValue($row['brick_count'] ?? null);
+        $sum_brikcoins += $normalizeValue($row['total_brk'] ?? null);
+        $sum_weight += $normalizeValue($row['weight'] ?? null);
+        $sum_expenses += $normalizeValue($row['tot_idr_exp_amt'] ?? null);
+        $sum_revenue += $normalizeValue($row['tot_idr_rev_amt'] ?? null);
+        $sum_costs += $normalizeValue($row['final_aes_plastic_cost_idr'] ?? null);
         $row_count++;
     }
 

--- a/includes/brikchain-inc.php
+++ b/includes/brikchain-inc.php
@@ -199,6 +199,38 @@
   color: var(--h1);
 }
 
+#brikchain-transactions {
+  font-family: 'Mulish', Arial, Helvetica, sans-serif;
+  color: var(--text-color);
+}
+
+#brikchain-transactions.dataTable thead th {
+  background-color: var(--table-background-heading);
+  color: var(--main-background);
+}
+
+#brikchain-transactions.dataTable tbody tr.odd,
+#brikchain-transactions.dataTable tbody tr:nth-child(odd) {
+  background-color: var(--table-background-2);
+}
+
+#brikchain-transactions.dataTable tbody tr.even,
+#brikchain-transactions.dataTable tbody tr:nth-child(even) {
+  background-color: var(--table-background-1);
+}
+
+#brikchain-transactions.dataTable tbody tr:hover {
+  background-color: var(--table-background-hover);
+}
+
+#brikchain-transactions a {
+  color: var(--text-color);
+}
+
+#brikchain-transactions a:hover {
+  color: var(--h1);
+}
+
 .dataTables_wrapper {
 	font-family: 'Mulish', Arial, Helvetica, sans-serif;
 }


### PR DESCRIPTION
## Summary
- guard the brikchain aggregation totals against null values before normalizing strings
- add dark-mode aware styling for the brikchain transactions DataTable to match the rest of the page

## Testing
- php -l en/brikchain.php

------
https://chatgpt.com/codex/tasks/task_e_68f225d421dc832babd80dceba3fcf97