### PR TITLE
Ensure latest trainings display when show_report is enabled

### DIFF
--- a/en/index.php
+++ b/en/index.php
@@ -192,7 +192,7 @@ include '../ecobricks_env.php';
     <div class="gallery-flex-container">
         <?php
         // Updated SQL query to include a WHERE clause and a LIMIT
-        $sql = "SELECT * FROM tb_trainings WHERE ready_to_show = 1 AND show_report = 1 ORDER BY training_id DESC LIMIT 12;";
+        $sql = "SELECT * FROM tb_trainings WHERE show_report = 1 ORDER BY training_id DESC LIMIT 12;";
         $result = $conn->query($sql);
 
         if ($result->num_rows > 0) {


### PR DESCRIPTION
## Summary
- update the GEA Trainings query on the English index page to depend solely on the show_report flag so the newest published trainings appear

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69121370cdc0832baea12d7c22b1b7d0)