### PR TITLE
Fix event date and Earthen feed mobile layout

### DIFF
--- a/css/stylesheet-2025.css
+++ b/css/stylesheet-2025.css
@@ -1469,4 +1469,130 @@ Login Selector Menu
 }
 
 .back-link:hover {
-    text-decoration: none;}
+    text-decoration: none;
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/* Earthen featured content feed */
+
+/* -------------------------------------------------------------------------- */
+
+.featured-earthen-content-feed {
+    margin: 60px auto;
+    max-width: 1200px;
+    padding: 0 20px;
+}
+
+.earthen-feed-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 24px;
+    margin-top: 20px;
+}
+
+.earthen-feed-card {
+    background: var(--module-bg, rgba(255, 255, 255, 0.75));
+    border: 1px solid rgba(25, 118, 84, 0.2);
+    border-radius: 18px;
+    display: flex;
+    flex-direction: column;
+    text-decoration: none;
+    color: inherit;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.05);
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+    overflow: hidden;
+}
+
+.earthen-feed-card:hover {
+    transform: translateY(-6px);
+    border-color: #52a675;
+    box-shadow: 0 18px 40px rgba(20, 78, 55, 0.2);
+}
+
+.earthen-feed-image {
+    position: relative;
+    padding-top: 56%;
+    overflow: hidden;
+    background: #0b1b13;
+}
+
+.earthen-feed-image img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.earthen-feed-content {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 18px 20px 22px;
+}
+
+.earthen-feed-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.95em;
+    color: var(--subdued-text);
+}
+
+.earthen-feed-meta img {
+    width: 22px;
+    height: 22px;
+}
+
+.earthen-feed-card h5 {
+    font-size: 1.25em;
+    margin: 0;
+    color: var(--text-color);
+}
+
+.earthen-feed-card p {
+    margin: 0;
+    color: var(--subdued-text);
+    font-size: 1em;
+    line-height: 1.4;
+}
+
+.earthen-feed-empty {
+    grid-column: 1 / -1;
+    text-align: center;
+    color: var(--subdued-text);
+    padding: 30px 10px;
+    border-radius: 16px;
+    border: 1px dashed rgba(25, 118, 84, 0.4);
+}
+
+@media screen and (max-width: 640px) {
+    .featured-earthen-content-feed {
+        padding: 0 10px;
+    }
+
+    .earthen-feed-grid {
+        display: flex;
+        flex-wrap: nowrap;
+        gap: 18px;
+        overflow-x: auto;
+        margin: 20px -5px 0;
+        padding: 0 5px 10px;
+        scroll-snap-type: x proximity;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .earthen-feed-card {
+        flex: 0 0 82%;
+        max-width: 82%;
+        border-radius: 16px;
+        scroll-snap-align: start;
+    }
+
+    .earthen-feed-card:last-child {
+        margin-right: 10px;
+    }
+}

--- a/en/index.php
+++ b/en/index.php
@@ -24,7 +24,7 @@ include '../ecobricks_env.php';
                     <div class="featured-content-text">
                         <div class="featured-content-title" data-lang-id="300-featured-content-1-title">Intro to Ecobricks Event</div>
                         <div class="featured-content-subtitle" data-lang-id="301-featured-content-1-subtitle">Join us for a live and free introductory course.  Learn the science, philosophy and essential techniques in our live community event 'Plastic, the Biosphere & Ecobricks'.  Zoom. Free.</div>
-                        <a class="content-button" href="https://gobrik.com/en/courses.php" data-lang-id="302-featured-content-1-button">↗️ Sunday, Nov. 16th Event</a>
+                        <a class="content-button" href="https://gobrik.com/en/courses.php" data-lang-id="302-featured-content-1-button">↗️ December 7th Event</a>
                     </div>
                 </div>
            </div>
@@ -172,6 +172,121 @@ include '../ecobricks_env.php';
         <a href="add-project.php" class="feature-button" data-lang-id="405b-post-project-button" aria-label="Post your project">➕ Post your project</a>
         <div class="feature-reference-links">Share your ecobrick application</div>-->
     </div>
+
+
+
+<!-- EARTHEN FEATURED CONTENT FEED -->
+
+<?php
+$earthenFeedUrl = 'https://earthen.io/rss';
+$earthenPosts = [];
+$earthenFeedError = '';
+$earthenFeedContent = @file_get_contents($earthenFeedUrl);
+
+if ($earthenFeedContent !== false) {
+    libxml_use_internal_errors(true);
+    $earthenFeedXml = simplexml_load_string($earthenFeedContent);
+    if ($earthenFeedXml !== false && isset($earthenFeedXml->channel->item)) {
+        $feedItems = $earthenFeedXml->channel->item;
+        $count = 0;
+        foreach ($feedItems as $item) {
+            $title = trim((string) $item->title);
+            $description = trim(strip_tags((string) $item->description));
+            if ($description === '' && isset($item->children('http://purl.org/rss/1.0/modules/content/')->encoded)) {
+                $description = trim(strip_tags((string) $item->children('http://purl.org/rss/1.0/modules/content/')->encoded));
+            }
+            if ($description !== '') {
+                if (function_exists('mb_strlen')) {
+                    if (mb_strlen($description) > 220) {
+                        $description = mb_substr($description, 0, 217) . '…';
+                    }
+                } elseif (strlen($description) > 220) {
+                    $description = substr($description, 0, 217) . '…';
+                }
+            }
+
+            $link = trim((string) $item->link);
+            $author = 'Earthen';
+            $dc = $item->children('http://purl.org/dc/elements/1.1/');
+            if ($dc && isset($dc->creator) && trim((string) $dc->creator) !== '') {
+                $author = trim((string) $dc->creator);
+            }
+
+            $imageUrl = '';
+            $media = $item->children('http://search.yahoo.com/mrss/');
+            if ($media && isset($media->thumbnail)) {
+                $thumbnailAttributes = $media->thumbnail->attributes();
+                if ($thumbnailAttributes && isset($thumbnailAttributes['url'])) {
+                    $imageUrl = (string) $thumbnailAttributes['url'];
+                }
+            }
+            if ($imageUrl === '' && $media && isset($media->content)) {
+                foreach ($media->content as $content) {
+                    $contentAttributes = $content->attributes();
+                    if ($contentAttributes && isset($contentAttributes['url'])) {
+                        $imageUrl = (string) $contentAttributes['url'];
+                        break;
+                    }
+                }
+            }
+            if ($imageUrl === '') {
+                if (preg_match('/<img[^>]+src=\"([^\"]+)\"/i', (string) $item->description, $matches)) {
+                    $imageUrl = $matches[1];
+                }
+            }
+            if ($imageUrl === '') {
+                $imageUrl = 'https://earthen.io/content/images/size/w1200/2022/09/earthen-og.jpg';
+            }
+
+            $earthenPosts[] = [
+                'title' => $title,
+                'description' => $description,
+                'link' => $link,
+                'author' => $author,
+                'image' => $imageUrl,
+            ];
+
+            $count++;
+            if ($count >= 4) {
+                break;
+            }
+        }
+    } else {
+        $earthenFeedError = 'Earthen stories are loading soon.';
+    }
+    libxml_clear_errors();
+} else {
+    $earthenFeedError = 'Earthen stories are loading soon.';
+}
+?>
+
+<div class="featured-earthen-content-feed" style="overflow-x:clip;">
+    <div class="feature-content-box">
+        <div class="feature-big-header"><h4>Earthen Latest</h4></div>
+        <div class="feature-sub-text">Fresh perspectives from the Earthen regenerative movement.</div>
+    </div>
+    <div class="earthen-feed-grid">
+        <?php if (!empty($earthenPosts)) : ?>
+            <?php foreach ($earthenPosts as $post) : ?>
+                <a class="earthen-feed-card" href="<?= htmlspecialchars($post['link'], ENT_QUOTES, 'UTF-8'); ?>" target="_blank" rel="noopener noreferrer">
+                    <div class="earthen-feed-image">
+                        <img src="<?= htmlspecialchars($post['image'], ENT_QUOTES, 'UTF-8'); ?>" alt="Featured image for <?= htmlspecialchars($post['title'], ENT_QUOTES, 'UTF-8'); ?>" loading="lazy" />
+                    </div>
+                    <div class="earthen-feed-content">
+                        <div class="earthen-feed-meta">
+                            <img src="https://earthen.io/favicon.png" alt="Earthen icon" loading="lazy" />
+                            <span><?= htmlspecialchars($post['author'], ENT_QUOTES, 'UTF-8'); ?></span>
+                        </div>
+                        <h5><?= htmlspecialchars($post['title'], ENT_QUOTES, 'UTF-8'); ?></h5>
+                        <p><?= htmlspecialchars($post['description'], ENT_QUOTES, 'UTF-8'); ?></p>
+                    </div>
+                </a>
+            <?php endforeach; ?>
+        <?php else : ?>
+            <div class="earthen-feed-empty"><?= htmlspecialchars($earthenFeedError, ENT_QUOTES, 'UTF-8'); ?></div>
+        <?php endif; ?>
+    </div>
+</div>
 
 
 

--- a/translations/index-en.js
+++ b/translations/index-en.js
@@ -3,7 +3,7 @@
 const en_Page_Translations = {
   "300-featured-content-1-title": "Intro to Ecobricks Event",
   "301-featured-content-1-subtitle": "Join us for a live and free introductory course.  Learn the science, philosophy and essential techniques in our live community event 'Plastic, the Biosphere & Ecobricks'.  Zoom. Free.",
-  "302-featured-content-1-button": "↗️ Sunday, Nov. 16th Event",
+  "302-featured-content-1-button": "↗️ December 7th Event",
   "300-featured-content-2-title": "What should green really mean?",
   "301-featured-content-2-subtitle": "Ecobricking is guided by the indigenous concept of Ayyew.  This ecological ethos inspires our Earthen ethics, our ecobricking and our understanding of Green.",
   "302-featured-content-2-button": "↗️ August 30th Event",

--- a/translations/index-es.js
+++ b/translations/index-es.js
@@ -6,7 +6,7 @@ const es_Page_Translations = {
 
     "300-featured-content-1-title": "Evento de Introducción a los Ecobricks",
     "301-featured-content-1-subtitle": "Únase a nosotros para un curso introductorio en vivo y gratuito. Aprenda la ciencia, la filosofía y las técnicas esenciales en nuestro evento comunitario en vivo 'Plástico, la Biosfera y los Ecobricks'. Zoom. Gratis.",
-    "302-featured-content-1-button": "↗️ Evento Domingo 16 de Nov.",
+    "302-featured-content-1-button": "↗️ Evento 7 de Dic.",
     "300-featured-content-2-title": "¿Qué debería significar realmente verde?",
     "301-featured-content-2-subtitle": "El ecobricking está guiado por el concepto indígena de Ayyew. Este ethos ecológico inspira nuestra ética terrenal, nuestro ecobricking y nuestra comprensión de lo Verde.",
     "302-featured-content-2-button": "↗️ Evento 30 de Agosto",

--- a/translations/index-fr.js
+++ b/translations/index-fr.js
@@ -2,7 +2,7 @@
 const fr_Page_Translations = {
   "300-featured-content-1-title": "Événement d'introduction aux écobriques",
   "301-featured-content-1-subtitle": "Rejoignez-nous pour un cours introductif en direct et gratuit. Apprenez la science, la philosophie et les techniques essentielles lors de notre événement communautaire en direct 'Plastique, la biosphère et les écobriques'. Zoom. Gratuit.",
-  "302-featured-content-1-button": "↗️ Événement du dim. 16 nov.",
+  "302-featured-content-1-button": "↗️ Événement du 7 déc.",
   "300-featured-content-2-title": "Que devrait vraiment signifier le vert ?",
   "301-featured-content-2-subtitle": "L'écobriquage est guidé par le concept indigène d'Ayyew. Cet ethos écologique inspire notre éthique terrestre, notre écobriquage et notre compréhension du Vert.",
   "302-featured-content-2-button": "↗️ Événement du 30 août",

--- a/translations/index-id.js
+++ b/translations/index-id.js
@@ -3,7 +3,7 @@
 const id_Page_Translations = {
   "300-featured-content-1-title": "Acara Pengantar Ecobrick",
   "301-featured-content-1-subtitle": "Bergabunglah dengan kami dalam kursus pengantar langsung dan gratis. Pelajari ilmu, filosofi, dan teknik penting dalam acara komunitas kami 'Plastik, Biosfer & Ecobrick'. Zoom. Gratis.",
-  "302-featured-content-1-button": "↗️ Acara Minggu 16 Nov.",
+  "302-featured-content-1-button": "↗️ Acara 7 Des.",
   "300-featured-content-2-title": "Apa arti hijau yang sebenarnya?",
   "301-featured-content-2-subtitle": "Ecobricking dipandu oleh konsep adat Ayyew. Etos ekologis ini menginspirasi etika Earthen kami, ecobricking kami, dan pemahaman kami tentang Hijau.",
   "302-featured-content-2-button": "↗️ Acara 30 Agustus",

--- a/translations/index-zh.js
+++ b/translations/index-zh.js
@@ -7,7 +7,7 @@ CHINESE TRANSLATION FOR ECOBRICKS.ORG
 const zh_Page_Translations = {
     "300-featured-content-1-title": "生态砖介绍活动",
     "301-featured-content-1-subtitle": "加入我们的免费直播入门课程。在我们的社区活动‘塑料、生物圈与生态砖’中学习科学、哲学和关键技巧。Zoom。免费。",
-    "302-featured-content-1-button": "↗️ 11月16日（周日）活动",
+    "302-featured-content-1-button": "↗️ 12月7日活动",
   "300-featured-content-2-title": "“绿色”究竟应该意味着什么？",
   "301-featured-content-2-subtitle": "生态砖实践受到本土理念 Ayyew 的指引。这种生态精神启发了我们的土伦理、生态砖制作以及我们对绿色的理解。",
   "302-featured-content-2-button": "↗️ 8月30日活动",


### PR DESCRIPTION
## Summary
- adjust the Intro to Ecobricks featured slider CTA to advertise the December 7th session and localize the new wording across every translation bundle
- improve the Earthen featured content feed so it behaves like a horizontal, swipeable carousel on phones while keeping the hover highlight on larger screens

## Testing
- php -l en/index.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691af057f540832bb6d0d29834347581)