### PR TITLE
Enhance Earthen feed CTA and metadata

### DIFF
--- a/css/stylesheet-2025.css
+++ b/css/stylesheet-2025.css
@@ -1581,6 +1581,11 @@ Login Selector Menu
     line-height: 1.4;
 }
 
+.earthen-feed-publication {
+    font-weight: 700;
+    color: var(--text-color);
+}
+
 .earthen-feed-empty {
     grid-column: 1 / -1;
     text-align: center;
@@ -1588,6 +1593,22 @@ Login Selector Menu
     padding: 30px 10px;
     border-radius: 16px;
     border: 1px dashed rgba(25, 118, 84, 0.4);
+}
+
+.earthen-feed-footer-text {
+    margin: 26px 0 10px;
+    color: var(--subdued-text);
+    font-size: 1.05em;
+    line-height: 1.5;
+}
+
+.earthen-subscriber-pill {
+    display: inline-block;
+    background: #52a675;
+    color: #fff;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-weight: 700;
 }
 
 @media screen and (max-width: 1024px) {

--- a/en/index.php
+++ b/en/index.php
@@ -287,6 +287,17 @@ if ($earthenFeedContent === false || $earthenFeedContent === null || $earthenFee
                 $imageUrl = 'https://earthen.io/content/images/size/w1200/2022/09/earthen-og.jpg';
             }
 
+            $publication = $earthenNewsletterName;
+            if (isset($item->category)) {
+                foreach ($item->category as $category) {
+                    $categoryName = trim((string) $category);
+                    if ($categoryName !== '') {
+                        $publication = $categoryName;
+                        break;
+                    }
+                }
+            }
+
             $earthenPosts[] = [
                 'title' => $title,
                 'description' => $description,
@@ -294,6 +305,7 @@ if ($earthenFeedContent === false || $earthenFeedContent === null || $earthenFee
                 'author' => $author,
                 'image' => $imageUrl,
                 'newsletter' => $earthenNewsletterName,
+                'publication' => $publication,
             ];
 
             $count++;
@@ -331,7 +343,7 @@ if ($earthenFeedContent === false || $earthenFeedContent === null || $earthenFee
                     <div class="earthen-feed-content">
                         <div class="earthen-feed-meta">
                             <img src="https://earthen.io/favicon.png" alt="Earthen icon" loading="lazy" />
-                            <span><?= htmlspecialchars($post['newsletter'], ENT_QUOTES, 'UTF-8'); ?></span>
+                            <span class="earthen-feed-publication"><?= htmlspecialchars($post['publication'], ENT_QUOTES, 'UTF-8'); ?></span>
                         </div>
                         <h5><?= htmlspecialchars($post['title'], ENT_QUOTES, 'UTF-8'); ?></h5>
                         <p><?= htmlspecialchars($post['description'], ENT_QUOTES, 'UTF-8'); ?></p>
@@ -342,6 +354,12 @@ if ($earthenFeedContent === false || $earthenFeedContent === null || $earthenFee
             <div class="earthen-feed-empty"><?= htmlspecialchars($earthenFeedError, ENT_QUOTES, 'UTF-8'); ?></div>
         <?php endif; ?>
     </div>
+
+    <div class="earthen-feed-footer-text">
+        We've got a collection of great regenerative newsletters on Earthen for you to select from. Join <span class="earthen-subscriber-pill">69,0231</span> others planet passionate subscribers.
+    </div>
+
+    <a class="feature-button" href="https://earthen.io" target="_blank" rel="noopener noreferrer">🌿 Explore Earthen</a>
 </div>
 
 


### PR DESCRIPTION
## Summary
- parse the Earthen RSS feed to extract per-post publication names and show them alongside the feed icon
- add descriptive copy, subscriber pill, and CTA link beneath the featured Earthen content feed
- style the new publication label and subscriber count pill within the Earthen feed section

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eccbdc8ec832b9e6ae588ddd91afc)