### PR TITLE
Handle null values in open books aggregates

### DIFF
--- a/en/open-books.php
+++ b/en/open-books.php
@@ -105,12 +105,12 @@ try {
     // Aggregate data
     while ($row = $result->fetch_assoc()) {
         // Normalize values by removing commas and converting to float
-        $sum_ecobricks += (float)str_replace(',', '', $row['brick_count']);
-        $sum_brikcoins += (float)str_replace(',', '', $row['total_brk']);
-        $sum_weight += (float)str_replace(',', '', $row['weight']);
-        $sum_expenses += (float)str_replace(',', '', $row['tot_idr_exp_amt']);
-        $sum_revenue += (float)str_replace(',', '', $row['tot_idr_rev_amt']);
-        $sum_costs += (float)str_replace(',', '', $row['final_aes_plastic_cost_idr']);
+        $sum_ecobricks += (float)str_replace(',', '', (string)($row['brick_count'] ?? '0'));
+        $sum_brikcoins += (float)str_replace(',', '', (string)($row['total_brk'] ?? '0'));
+        $sum_weight += (float)str_replace(',', '', (string)($row['weight'] ?? '0'));
+        $sum_expenses += (float)str_replace(',', '', (string)($row['tot_idr_exp_amt'] ?? '0'));
+        $sum_revenue += (float)str_replace(',', '', (string)($row['tot_idr_rev_amt'] ?? '0'));
+        $sum_costs += (float)str_replace(',', '', (string)($row['final_aes_plastic_cost_idr'] ?? '0'));
         $row_count++;
     }
 


### PR DESCRIPTION
## Summary
- coalesce null financial fields before stripping commas to prevent PHP deprecation warnings
- keep aggregation logic stable by defaulting missing values to zero

## Testing
- php -l en/open-books.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e8a409d0c832bb900a93629fcb7b8)