### PR TITLE
Fix SQL injection in ecobrick/project/training detail pages

### DIFF
--- a/en/details-brk-trans.php
+++ b/en/details-brk-trans.php
@@ -257,9 +257,12 @@ b {font-weight: 500;}
 // Get the contents from the Transaction table as an ordered View, using the transaction id from the URL.
 $transactionId = $_GET['tran_id'];
 
-$sql = "SELECT * FROM vw_brk_tran_ledgerid_asc WHERE chain_ledger_id = " . $transactionId;
+$sql = "SELECT * FROM vw_brk_tran_ledgerid_asc WHERE chain_ledger_id = ?";
 
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("i", $transactionId);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 	//echo "</br><h3>" . $transactionId . "</h1>";
     //  Output data of each row

--- a/en/details-cash-trans.php
+++ b/en/details-cash-trans.php
@@ -277,9 +277,12 @@ strong {
             $cashTranId = $_GET['cash_tran_id'];
 
             // Refered to  https://www.w3schools.com/php/php_mysql_select_where.asp1
-            $sql = "SELECT * FROM tb_cash_transaction WHERE cash_tran_id = " . $cashTranId;
+            $sql = "SELECT * FROM tb_cash_transaction WHERE cash_tran_id = ?";
 
-            $result = $conn->query($sql);
+            $stmt = $conn->prepare($sql);
+            $stmt->bind_param("i", $cashTranId);
+            $stmt->execute();
+            $result = $stmt->get_result();
             if ($result->num_rows > 0) {
 
                 //  echo "<h1> Use Serial Number from URL => " . $serialNo ."</h1>"; Output data of each row

--- a/en/details-ecobrick-page.php
+++ b/en/details-ecobrick-page.php
@@ -13,9 +13,12 @@
 	// Get the contents from the Ecobrick table as an ordered View, using the serial_no from the URL.  See: https://www.w3schools.com/php/php_mysql_select_where.asp1
 	$serialNo = $_GET['serial_no'];
 
-	$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = '" . $serialNo . "'";
+	$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = ?";
 
-	$result = $conn->query($sql);
+	$stmt = $conn->prepare($sql);
+	$stmt->bind_param("s", $serialNo);
+	$stmt->execute();
+	$result = $stmt->get_result();
 	if ($result->num_rows > 0) {
 	
     while($array = $result->fetch_assoc()) {

--- a/es/details-brk-trans.php
+++ b/es/details-brk-trans.php
@@ -257,9 +257,12 @@ b {font-weight: 500;}
 // Get the contents from the Transaction table as an ordered View, using the transaction id from the URL.
 $transactionId = $_GET['tran_id'];
 
-$sql = "SELECT * FROM vw_brk_tran_ledgerid_asc WHERE chain_ledger_id = " . $transactionId;
+$sql = "SELECT * FROM vw_brk_tran_ledgerid_asc WHERE chain_ledger_id = ?";
 
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("i", $transactionId);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 	//echo "</br><h3>" . $transactionId . "</h1>";
     //  Output data of each row

--- a/es/details-cash-trans.php
+++ b/es/details-cash-trans.php
@@ -277,9 +277,12 @@ strong {
             $cashTranId = $_GET['cash_tran_id'];
 
             // Refered to  https://www.w3schools.com/php/php_mysql_select_where.asp1
-            $sql = "SELECT * FROM tb_cash_transaction WHERE cash_tran_id = " . $cashTranId;
+            $sql = "SELECT * FROM tb_cash_transaction WHERE cash_tran_id = ?";
 
-            $result = $conn->query($sql);
+            $stmt = $conn->prepare($sql);
+            $stmt->bind_param("i", $cashTranId);
+            $stmt->execute();
+            $result = $stmt->get_result();
             if ($result->num_rows > 0) {
 
                 //  echo "<h1> Use Serial Number from URL => " . $serialNo ."</h1>"; Output data of each row

--- a/es/details-ecobrick-page.php
+++ b/es/details-ecobrick-page.php
@@ -14,9 +14,12 @@
 	// Get the contents from the Ecobrick table as an ordered View, using the serial_no from the URL.  See: https://www.w3schools.com/php/php_mysql_select_where.asp1
 	$serialNo = $_GET['serial_no'];
 
-	$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = '" . $serialNo . "'";
+	$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = ?";
 
-	$result = $conn->query($sql);
+	$stmt = $conn->prepare($sql);
+	$stmt->bind_param("s", $serialNo);
+	$stmt->execute();
+	$result = $stmt->get_result();
 	if ($result->num_rows > 0) {
 	
     while($array = $result->fetch_assoc()) {

--- a/es/details-ecobrick-page2.php
+++ b/es/details-ecobrick-page2.php
@@ -14,9 +14,12 @@
 	// Get the contents from the Ecobrick table as an ordered View, using the serial_no from the URL.  See: https://www.w3schools.com/php/php_mysql_select_where.asp1
 	$serialNo = $_GET['serial_no'];
 
-	$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = '" . $serialNo . "'";
+	$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = ?";
 
-	$result = $conn->query($sql);
+	$stmt = $conn->prepare($sql);
+	$stmt->bind_param("s", $serialNo);
+	$stmt->execute();
+	$result = $stmt->get_result();
 	if ($result->num_rows > 0) {
 	
     while($array = $result->fetch_assoc()) {

--- a/fr/details-brk-trans.php
+++ b/fr/details-brk-trans.php
@@ -257,9 +257,12 @@ b {font-weight: 500;}
 // Get the contents from the Transaction table as an ordered View, using the transaction id from the URL.
 $transactionId = $_GET['tran_id'];
 
-$sql = "SELECT * FROM vw_brk_tran_ledgerid_asc WHERE chain_ledger_id = " . $transactionId;
+$sql = "SELECT * FROM vw_brk_tran_ledgerid_asc WHERE chain_ledger_id = ?";
 
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("i", $transactionId);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 	//echo "</br><h3>" . $transactionId . "</h1>";
     //  Output data of each row

--- a/fr/details-cash-trans.php
+++ b/fr/details-cash-trans.php
@@ -277,9 +277,12 @@ strong {
             $cashTranId = $_GET['cash_tran_id'];
 
             // Refered to  https://www.w3schools.com/php/php_mysql_select_where.asp1
-            $sql = "SELECT * FROM tb_cash_transaction WHERE cash_tran_id = " . $cashTranId;
+            $sql = "SELECT * FROM tb_cash_transaction WHERE cash_tran_id = ?";
 
-            $result = $conn->query($sql);
+            $stmt = $conn->prepare($sql);
+            $stmt->bind_param("i", $cashTranId);
+            $stmt->execute();
+            $result = $stmt->get_result();
             if ($result->num_rows > 0) {
 
                 //  echo "<h1> Use Serial Number from URL => " . $serialNo ."</h1>"; Output data of each row

--- a/fr/details-ecobrick-page.php
+++ b/fr/details-ecobrick-page.php
@@ -14,9 +14,12 @@
 	// Get the contents from the Ecobrick table as an ordered View, using the serial_no from the URL.  See: https://www.w3schools.com/php/php_mysql_select_where.asp1
 	$serialNo = $_GET['serial_no'];
 
-	$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = '" . $serialNo . "'";
+	$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = ?";
 
-	$result = $conn->query($sql);
+	$stmt = $conn->prepare($sql);
+	$stmt->bind_param("s", $serialNo);
+	$stmt->execute();
+	$result = $stmt->get_result();
 	if ($result->num_rows > 0) {
 	
     while($array = $result->fetch_assoc()) {

--- a/fr/details-ecobrick-page2.php
+++ b/fr/details-ecobrick-page2.php
@@ -14,9 +14,12 @@
 	// Get the contents from the Ecobrick table as an ordered View, using the serial_no from the URL.  See: https://www.w3schools.com/php/php_mysql_select_where.asp1
 	$serialNo = $_GET['serial_no'];
 
-	$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = '" . $serialNo . "'";
+	$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = ?";
 
-	$result = $conn->query($sql);
+	$stmt = $conn->prepare($sql);
+	$stmt->bind_param("s", $serialNo);
+	$stmt->execute();
+	$result = $stmt->get_result();
 	if ($result->num_rows > 0) {
 	
     while($array = $result->fetch_assoc()) {

--- a/fr/project.php
+++ b/fr/project.php
@@ -21,11 +21,12 @@ ini_set('display_errors', 1);?>
 
 	$projectId = $_GET['project_id'];
 
-	$sql = "SELECT * FROM tb_projects WHERE project_id = '" . $projectId . "'";
+	$sql = "SELECT * FROM tb_projects WHERE project_id = ?";
 
-
-
-	$result = $conn->query($sql);
+	$stmt = $conn->prepare($sql);
+	$stmt->bind_param("i", $projectId);
+	$stmt->execute();
+	$result = $stmt->get_result();
 	if ($result->num_rows > 0) {
 	
     while($array = $result->fetch_assoc()) {

--- a/id/details-brk-trans.php
+++ b/id/details-brk-trans.php
@@ -257,9 +257,12 @@ b {font-weight: 500;}
 // Get the contents from the Transaction table as an ordered View, using the transaction id from the URL.
 $transactionId = $_GET['tran_id'];
 
-$sql = "SELECT * FROM vw_brk_tran_ledgerid_asc WHERE chain_ledger_id = " . $transactionId;
+$sql = "SELECT * FROM vw_brk_tran_ledgerid_asc WHERE chain_ledger_id = ?";
 
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("i", $transactionId);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 	//echo "</br><h3>" . $transactionId . "</h1>";
     //  Output data of each row

--- a/id/details-cash-trans.php
+++ b/id/details-cash-trans.php
@@ -277,9 +277,12 @@ strong {
             $cashTranId = $_GET['cash_tran_id'];
 
             // Refered to  https://www.w3schools.com/php/php_mysql_select_where.asp1
-            $sql = "SELECT * FROM tb_cash_transaction WHERE cash_tran_id = " . $cashTranId;
+            $sql = "SELECT * FROM tb_cash_transaction WHERE cash_tran_id = ?";
 
-            $result = $conn->query($sql);
+            $stmt = $conn->prepare($sql);
+            $stmt->bind_param("i", $cashTranId);
+            $stmt->execute();
+            $result = $stmt->get_result();
             if ($result->num_rows > 0) {
 
                 //  echo "<h1> Use Serial Number from URL => " . $serialNo ."</h1>"; Output data of each row

--- a/id/details-ecobrick-page.php
+++ b/id/details-ecobrick-page.php
@@ -18,9 +18,12 @@ include '../ssp.class.php';
 $serialNo = $_GET['serial_no'];
 
 // Référence à https://www.w3schools.com/php/php_mysql_select_where.asp1
-$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = '" . $serialNo . "'";
+$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = ?";
 
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("s", $serialNo);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 
     //  echo "<h1> Utiliser le numéro de série de l'URL => " . $serialNo ."</h1>"; Données de sortie de chaque ligne 

--- a/id/details-ecobrick-page2.php
+++ b/id/details-ecobrick-page2.php
@@ -14,9 +14,12 @@
 	// Get the contents from the Ecobrick table as an ordered View, using the serial_no from the URL.  See: https://www.w3schools.com/php/php_mysql_select_where.asp1
 	$serialNo = $_GET['serial_no'];
 
-	$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = '" . $serialNo . "'";
+	$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = ?";
 
-	$result = $conn->query($sql);
+	$stmt = $conn->prepare($sql);
+	$stmt->bind_param("s", $serialNo);
+	$stmt->execute();
+	$result = $stmt->get_result();
 	if ($result->num_rows > 0) {
 	
     while($array = $result->fetch_assoc()) {

--- a/meta/details-ecobrick-en.php
+++ b/meta/details-ecobrick-en.php
@@ -8,9 +8,12 @@ include '../ecobricks_env.php';
 $serialNo = $_GET['serial_no'];
 
 // Refered to  https://www.w3schools.com/php/php_mysql_select_where.asp1
-$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = " . $serialNo;
+$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = ?";
 
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("s", $serialNo);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 	
     //  echo "<h1> Use Serial Number from URL => " . $serialNo ."</h1>"; Output data of each row 

--- a/meta/details-ecobrick-es.php
+++ b/meta/details-ecobrick-es.php
@@ -8,9 +8,12 @@ include '../ecobricks_env.php';
 $serialNo = $_GET['serial_no'];
 
 // Refered to  https://www.w3schools.com/php/php_mysql_select_where.asp1
-$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = " . $serialNo;
+$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = ?";
 
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("s", $serialNo);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 	
     //  echo "<h1> Use Serial Number from URL => " . $serialNo ."</h1>"; Output data of each row 

--- a/meta/details-ecobrick-fr.php
+++ b/meta/details-ecobrick-fr.php
@@ -8,9 +8,12 @@ include '../ecobricks_env.php';
 $serialNo = $_GET['serial_no'];
 
 // Refered to  https://www.w3schools.com/php/php_mysql_select_where.asp1
-$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = " . $serialNo;
+$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = ?";
 
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("s", $serialNo);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 	
     //  echo "<h1> Use Serial Number from URL => " . $serialNo ."</h1>"; Output data of each row 
@@ -31,7 +34,7 @@ if ($result->num_rows > 0) {
         echo '<meta property="og:title"         content="Écobrique '. $array["serial_no"] .' | '. $array["weight_g"] .'g of plastic sequestered by '. $array["owner"] .' in '. $array["location_full"] .'.">';
         echo '<meta property="og:description"   content="Une écobrique authentifiée qui a été publiée et archivée sur la blockchain manuelle brikcoin sur ' . $array["last_validation_ts"] .'"/>';
         echo '<meta property="og:image"         content="'. $array["ecobrick_full_photo_url"] .'"/>';
-        echo '<meta property="og:image:alt"     content="L'enregistrement brikchain d'une écobrick authentifiée sur la brikchain"/>';
+        echo '<meta property="og:image:alt"     content="L\'enregistrement brikchain d\'une écobrick authentifiée sur la brikchain"/>';
         echo '<meta property="og:locale" content="fr_FR" />';
         echo '<meta property="og:type"          content="website">';
  	   

--- a/meta/details-ecobrick-id.php
+++ b/meta/details-ecobrick-id.php
@@ -8,9 +8,12 @@ include '../ecobricks_env.php';
 $serialNo = $_GET['serial_no'];
 
 // Refered to  https://www.w3schools.com/php/php_mysql_select_where.asp1
-$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = " . $serialNo;
+$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = ?";
 
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("s", $serialNo);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 	
     //  echo "<h1> Use Serial Number from URL => " . $serialNo ."</h1>"; Output data of each row 

--- a/meta/project-en.php
+++ b/meta/project-en.php
@@ -7,10 +7,12 @@ include '../ecobricks_env.php';
 
 $projectId = $_GET['project_id'];
 
-$sql = "SELECT * FROM tb_projects WHERE project_id = '" . $projectId . "'";
+$sql = "SELECT * FROM tb_projects WHERE project_id = ?";
 
-
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("i", $projectId);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 	
     while($array = $result->fetch_assoc()) {

--- a/meta/project-es.php
+++ b/meta/project-es.php
@@ -7,10 +7,12 @@ include '../ecobricks_env.php';
 
 $projectId = $_GET['project_id'];
 
-$sql = "SELECT * FROM tb_projects WHERE project_id = '" . $projectId . "'";
+$sql = "SELECT * FROM tb_projects WHERE project_id = ?";
 
-
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("i", $projectId);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 	
     while($array = $result->fetch_assoc()) {

--- a/meta/project-fr.php
+++ b/meta/project-fr.php
@@ -7,10 +7,12 @@ include '../ecobricks_env.php';
 
 $projectId = $_GET['project_id'];
 
-$sql = "SELECT * FROM tb_projects WHERE project_id = '" . $projectId . "'";
+$sql = "SELECT * FROM tb_projects WHERE project_id = ?";
 
-
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("i", $projectId);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 	
     while($array = $result->fetch_assoc()) {

--- a/meta/project-id.php
+++ b/meta/project-id.php
@@ -7,10 +7,12 @@ include '../ecobricks_env.php';
 
 $projectId = $_GET['project_id'];
 
-$sql = "SELECT * FROM tb_projects WHERE project_id = '" . $projectId . "'";
+$sql = "SELECT * FROM tb_projects WHERE project_id = ?";
 
-
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("i", $projectId);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 	
     while($array = $result->fetch_assoc()) {

--- a/meta/training-en.php
+++ b/meta/training-en.php
@@ -7,10 +7,12 @@ include '../ecobricks_env.php';
 
 $trainingId = isset($_GET['training_id']) ? $_GET['training_id'] : (isset($_GET['id']) ? $_GET['id'] : 0);
 
-$sql = "SELECT * FROM tb_trainings WHERE training_id = '" . $trainingId . "'";
+$sql = "SELECT * FROM tb_trainings WHERE training_id = ?";
 
-
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("i", $trainingId);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 	
     while($array = $result->fetch_assoc()) {

--- a/meta/training-es.php
+++ b/meta/training-es.php
@@ -7,10 +7,12 @@ include '../ecobricks_env.php';
 
 $trainingId = isset($_GET['training_id']) ? $_GET['training_id'] : (isset($_GET['id']) ? $_GET['id'] : 0);
 
-$sql = "SELECT * FROM tb_trainings WHERE training_id = '" . $trainingId . "'";
+$sql = "SELECT * FROM tb_trainings WHERE training_id = ?";
 
-
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("i", $trainingId);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 	
     while($array = $result->fetch_assoc()) {

--- a/meta/training-fr.php
+++ b/meta/training-fr.php
@@ -7,10 +7,12 @@ include '../ecobricks_env.php';
 
 $trainingId = isset($_GET['training_id']) ? $_GET['training_id'] : (isset($_GET['id']) ? $_GET['id'] : 0);
 
-$sql = "SELECT * FROM tb_trainings WHERE training_id = '" . $trainingId . "'";
+$sql = "SELECT * FROM tb_trainings WHERE training_id = ?";
 
-
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("i", $trainingId);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 	
     while($array = $result->fetch_assoc()) {

--- a/meta/training-id.php
+++ b/meta/training-id.php
@@ -7,10 +7,12 @@ include '../ecobricks_env.php';
 
 $trainingId = isset($_GET['training_id']) ? $_GET['training_id'] : (isset($_GET['id']) ? $_GET['id'] : 0);
 
-$sql = "SELECT * FROM tb_trainings WHERE training_id = '" . $trainingId . "'";
+$sql = "SELECT * FROM tb_trainings WHERE training_id = ?";
 
-
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("i", $trainingId);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 	
     while($array = $result->fetch_assoc()) {

--- a/meta/training-zh.php
+++ b/meta/training-zh.php
@@ -4,9 +4,12 @@ include '../ecobricks_env.php';
 
 $trainingId = isset($_GET['training_id']) ? $_GET['training_id'] : (isset($_GET['id']) ? $_GET['id'] : 0);
 
-$sql = "SELECT * FROM tb_trainings WHERE training_id = '" . $trainingId . "'";
+$sql = "SELECT * FROM tb_trainings WHERE training_id = ?";
 
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("i", $trainingId);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 
     while($array = $result->fetch_assoc()) {

--- a/meta/transition-es.php
+++ b/meta/transition-es.php
@@ -7,10 +7,12 @@ include '../ecobricks_env.php';
 
 $trainingId = $_GET['training_id'];
 
-$sql = "SELECT * FROM tb_trainings WHERE training_id = '" . $trainingId . "'";
+$sql = "SELECT * FROM tb_trainings WHERE training_id = ?";
 
-
-$result = $conn->query($sql);
+$stmt = $conn->prepare($sql);
+$stmt->bind_param("i", $trainingId);
+$stmt->execute();
+$result = $stmt->get_result();
 if ($result->num_rows > 0) {
 	
     while($array = $result->fetch_assoc()) {


### PR DESCRIPTION
## Summary

Replaces string-concatenated `$_GET` input in SQL `WHERE` clauses with mysqli prepared statements (`prepare()` + `bind_param()`) across 30 files:

- `*/details-ecobrick-page.php`, `*/details-ecobrick-page2.php` (serial_no)
- `*/details-brk-trans.php` (tran_id)
- `*/details-cash-trans.php` (cash_tran_id)
- `fr/project.php` (project_id)
- `meta/details-ecobrick-{en,es,fr,id}.php` (serial_no)
- `meta/project-{en,es,fr,id}.php` (project_id)
- `meta/training-{en,es,fr,id,zh}.php`, `meta/transition-es.php` (training_id)

Before this change, e.g. `meta/details-ecobrick-en.php` did:
```php
$serialNo = $_GET['serial_no'];
$sql = "SELECT * FROM tb_ecobricks WHERE serial_no = " . $serialNo;
```
Anyone could pass arbitrary SQL through `serial_no`/`project_id`/`training_id`/`tran_id`/`cash_tran_id` in the URL. This pattern already exists correctly elsewhere in the codebase (e.g. `es/add_project.php`), this PR just applies it consistently to the files that were missing it.

Also fixes an unrelated pre-existing fatal parse error in `meta/details-ecobrick-fr.php` (unescaped apostrophes inside a single-quoted PHP string on the `og:image:alt` line) — found while lint-checking this change, since that file was completely broken before this PR (would 500 on every French ecobrick detail page).

`en/details-project-page.php` was intentionally left out: its query already references an undefined `$projectId` variable that's never populated from `$_GET`, so there's no live injection there today — just dead/broken code from an apparent copy-paste, which is a separate bug outside this security fix's scope.

## Testing

No local DB/test suite is available (`ecobricks_env.php`/`gobrikconn_env.php` are intentionally not in the repo). Verified with:
- `php -l` on all 30 changed files — no syntax errors.
- Manual review confirming `$stmt->get_result()` preserves the exact `mysqli_result` interface (`num_rows`, `fetch_assoc()`) used by the unchanged code below each query, so no other behavior changes.

Given there's no CI/test suite in this repo, recommend testing on `beta.ecobricks.org` (or a staging DB) before merging: hit each changed URL with a valid id and confirm the page still renders the same data as before.