### PR TITLE
Require admin auth on /scripts/ database-write endpoints

### DIFF
--- a/includes/require-admin.php
+++ b/includes/require-admin.php
@@ -1,0 +1,40 @@
+<?php
+// Auth gate for internal admin-only scripts under /scripts/ that write to the
+// database (data migration/processing tools with no public UI entry point).
+//
+// Requires an admin_env.php file at the repo root (NOT committed, like
+// ecobricks_env.php / gobrikconn_env.php) defining a secret token, using
+// PHP's define() function with the constant name ADMIN_TOKEN and a long
+// random string value.
+//
+// Pass it once as ?admin_token=... (or POST field admin_token); the session
+// remembers it so the multi-step migration scripts can keep redirecting to
+// each other without re-authenticating every request.
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+if (empty($_SESSION['gea_admin_authenticated'])) {
+    $adminEnvPath = __DIR__ . '/../admin_env.php';
+
+    if (!file_exists($adminEnvPath)) {
+        if (!headers_sent()) {
+            http_response_code(503);
+        }
+        die('Admin authentication is not configured on this server.');
+    }
+
+    require_once $adminEnvPath;
+
+    $providedToken = (string) ($_POST['admin_token'] ?? $_GET['admin_token'] ?? '');
+
+    if (!defined('ADMIN_TOKEN') || $providedToken === '' || !hash_equals(ADMIN_TOKEN, $providedToken)) {
+        if (!headers_sent()) {
+            http_response_code(403);
+        }
+        die('Forbidden: admin authentication required.');
+    }
+
+    $_SESSION['gea_admin_authenticated'] = true;
+}

--- a/scripts/process_ecobrick-full.php
+++ b/scripts/process_ecobrick-full.php
@@ -1,3 +1,4 @@
+<?php require_once '../includes/require-admin.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/scripts/process_ecobrick-old.php
+++ b/scripts/process_ecobrick-old.php
@@ -1,4 +1,4 @@
-
+<?php require_once '../includes/require-admin.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/scripts/process_ecobrick.php
+++ b/scripts/process_ecobrick.php
@@ -1,3 +1,4 @@
+<?php require_once '../includes/require-admin.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/scripts/process_ecobrick_for_maker_id.php
+++ b/scripts/process_ecobrick_for_maker_id.php
@@ -1,4 +1,4 @@
-
+<?php require_once '../includes/require-admin.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/scripts/process_training.php
+++ b/scripts/process_training.php
@@ -2,6 +2,7 @@
 // PART 1 of the code
 // process_training.php
 
+require_once '../includes/require-admin.php';
 include '../ecobricks_env.php';
 
 // Knack API settings

--- a/scripts/process_training2.php
+++ b/scripts/process_training2.php
@@ -1,8 +1,8 @@
-
 <?php
 // PART 1 of the code
 // process_training2.php
 
+require_once '../includes/require-admin.php';
 include '../ecobricks_env.php';
 
 // Knack API settings

--- a/scripts/process_training3.php
+++ b/scripts/process_training3.php
@@ -2,6 +2,7 @@
 // PART 1 of the code
 // process_training2.php
 
+require_once '../includes/require-admin.php';
 include '../ecobricks_env.php';
 
 // Knack API settings

--- a/scripts/training.php
+++ b/scripts/training.php
@@ -1,4 +1,5 @@
 <?php
+require_once '../includes/require-admin.php';
 include '../ecobricks_env.php';
 
 $training_id = $_GET['training_id'];

--- a/scripts/update-training-database.php
+++ b/scripts/update-training-database.php
@@ -1,5 +1,6 @@
 <?php
 // PART 4: Database Update
+require_once '../includes/require-admin.php';
 include '../ecobricks_env.php';
 
 $training_id = $_GET['training_id'];


### PR DESCRIPTION
## Summary

`/scripts/` contains internal data-migration/admin tools: `process_ecobrick-full.php`, `process_ecobrick-old.php`, `process_ecobrick.php`, `process_ecobrick_for_maker_id.php`, `process_training.php`, `process_training2.php`, `process_training3.php`, `update-training-database.php`, and `training.php` (which has a `DELETE FROM tb_trainings` action). None of these are linked from any public page or referenced by any front-end JS (verified by grepping the whole repo for their filenames), yet they had **zero authentication** — anyone who found/guessed the URL could trigger INSERT/UPDATE/DELETE against the live GoBrik database.

This PR adds a shared gate, `includes/require-admin.php`:
- Requires a secret token (`?admin_token=...` or POST field `admin_token`) matched with `hash_equals()` against `ADMIN_TOKEN`, defined in a new `admin_env.php` file at the repo root.
- `admin_env.php` is **not committed** — it already matches the repo's existing `*_env.php` gitignore rule, same pattern as `ecobricks_env.php`/`gobrikconn_env.php`.
- Once validated, stores it in `$_SESSION` so the existing multi-step flows (these scripts redirect to each other, e.g. `process_training2.php` → `training.php?training_id=...`) don't need the token on every request.
- Fails closed: if `admin_env.php` doesn't exist on the server, every gated script 503s instead of silently allowing access.

**You'll need to create `admin_env.php` on the server** (and locally if testing) with:
```php
<?php define('ADMIN_TOKEN', 'a-long-random-string'); ?>
```

### Left untouched, on purpose

- `scripts/carbon_check.php` — fetched directly by public JS (`js/website-carbon-badges.js`), must stay open.
- `scripts/ajax-*.php`, `scripts/get-*.php`, `scripts/training-detail.php`, `scripts/ssp.class.php` — all read-only (no INSERT/UPDATE/DELETE), and appear to mirror the site's public "Open Books" transparency APIs under `/api/`. Didn't want to guess at gating these without confirming with maintainers whether they're meant to be public, since gating them could break the transparency features the org is built around. Happy to do a follow-up PR if you'd like these locked down too.

## Testing

No test suite/CI in this repo. Verified the gate itself in isolation with PHP's built-in server (`php -S`) against a throwaway fixture mirroring the real include structure:
- No token → `403 Forbidden`
- Wrong token → `403 Forbidden`
- Correct `?admin_token=...` → passes through, sets session
- Follow-up request with the session cookie but no token → still passes (session remembered)

Also ran `php -l` on all 10 changed/added files — no syntax errors.

Note: an earlier draft of `require-admin.php`'s doc comment had a `<?php ... ?>` code example *inside* a `//` comment — PHP closes tag mode on a literal `?>` even inside a line comment, which silently turned the entire rest of the file into inert HTML output (no fatal error, `php -l` passes, but the auth check never runs). Caught this by actually exercising the gate end-to-end rather than relying on lint alone; the shipped version avoids embedding a literal closing tag in the comment.