### PR TITLE
Stop forcing display_errors in production and leaking DB errors

### DIFF
--- a/404-handler.php
+++ b/404-handler.php
@@ -1,8 +1,5 @@
 
 <?php
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
-
 // Get the original request URI
 $request_uri = $_SERVER['REQUEST_URI'];
 

--- a/api/fetch_cash_trans.php
+++ b/api/fetch_cash_trans.php
@@ -1,9 +1,4 @@
 <?php
-// Enable error reporting for debugging
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
-
 // Include the GoBrik server connection credentials
 require_once '../gobrikconn_env.php';
 
@@ -22,8 +17,9 @@ $sql = "SELECT * FROM tb_cash_transaction WHERE cash_tran_id = ?";
 
 $stmt = $gobrik_conn->prepare($sql);
 if (!$stmt) {
+    error_log("fetch_cash_trans.php prepare failed: " . $gobrik_conn->error);
     http_response_code(500); // Internal Server Error
-    echo json_encode(['error' => 'Failed to prepare database query: ' . $gobrik_conn->error]);
+    echo json_encode(['error' => 'Failed to prepare database query.']);
     exit;
 }
 

--- a/api/fetch_expenses_trans.php
+++ b/api/fetch_expenses_trans.php
@@ -1,9 +1,4 @@
 <?php
-// Enable error reporting for debugging
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
-
 // Include the GoBrik server connection credentials
 require_once '../gobrikconn_env.php';
 
@@ -23,8 +18,9 @@ $result = $gobrik_conn->query($sql);
 
 // Check for query execution errors
 if (!$result) {
+    error_log("fetch_expenses_trans.php query failed: " . $gobrik_conn->error);
     http_response_code(500); // Internal Server Error
-    echo json_encode(["error" => "Database query failed: " . $gobrik_conn->error]);
+    echo json_encode(["error" => "Database query failed."]);
     exit;
 }
 

--- a/api/fetch_revenues_trans.php
+++ b/api/fetch_revenues_trans.php
@@ -18,8 +18,9 @@ $result = $gobrik_conn->query($sql);
 
 // Check for query execution errors
 if (!$result) {
+    error_log("fetch_revenues_trans.php query failed: " . $gobrik_conn->error);
     http_response_code(500);
-    echo json_encode(["error" => "Database query failed: " . $gobrik_conn->error]);
+    echo json_encode(["error" => "Database query failed."]);
     exit;
 }
 

--- a/en/404-handler.php
+++ b/en/404-handler.php
@@ -1,8 +1,5 @@
 
 <?php
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
-
 // Get the original request URI
 $request_uri = $_SERVER['REQUEST_URI'];
 

--- a/en/brik-imports.php
+++ b/en/brik-imports.php
@@ -1,8 +1,5 @@
 <?php
 
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
-
 include '../ecobricks_env.php';
 $conn->set_charset("utf8mb4");
 

--- a/en/delete-ecobrick.php
+++ b/en/delete-ecobrick.php
@@ -1,8 +1,5 @@
 <?php
 
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
-
 include '../ecobricks_env.php';
 
 $response = ['success' => false];

--- a/en/project.php
+++ b/en/project.php
@@ -2,9 +2,7 @@
 <HTML lang="en"> 
 <HEAD>
 <META charset="UTF-8">
-<?php $lang='en';
-error_reporting(E_ALL);
-ini_set('display_errors', 1);?>
+<?php $lang='en';?>
 <?php $version='2.12';?>
 <?php $page='project';?>
 

--- a/en/training.php
+++ b/en/training.php
@@ -7,9 +7,7 @@
 <HEAD>
 <META charset="UTF-8">
 
-<?php $lang='en';
-error_reporting(E_ALL);
-ini_set('display_errors', 1);?>
+<?php $lang='en';?>
 
 
 <?php 

--- a/en/upload-success.php
+++ b/en/upload-success.php
@@ -1,8 +1,5 @@
 <?php
 
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
-
 include '../ecobricks_env.php';
 
 if (isset($_GET['id'])) {

--- a/es/add-project-images.php
+++ b/es/add-project-images.php
@@ -1,7 +1,5 @@
 <?php
 
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
 include '../ecobricks_env.php';
 
 $error_message = '';
@@ -70,7 +68,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['project_id'])) {
         $update_stmt = $conn->prepare($update_sql);
         $update_stmt->bind_param($db_types, ...$db_values);
         if (!$update_stmt->execute()) {
-            $error_message .= "Database update failed: " . $update_stmt->error;
+            error_log("add-project-images.php update failed: " . $update_stmt->error);
+            $error_message .= "Database update failed.";
         }
         $update_stmt->close();
     }

--- a/es/add-project.php
+++ b/es/add-project.php
@@ -1,8 +1,5 @@
 <?php
 
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
-
 include '../ecobricks_env.php';
 $conn->set_charset("utf8mb4");
 
@@ -59,11 +56,13 @@ if ($stmt->execute()) {
         $conn->close();
             echo "<script>window.location.href = 'add-project-images.php?project_id=" . $project_id . "';</script>";
         } else {
-            echo "Error: " . $stmt->error . "<br>";
+            error_log("add-project.php execute failed: " . $stmt->error);
+            echo "Error: something went wrong saving your project. Please try again.<br>";
         }
         $stmt->close();
     } else {
-        echo "Prepare failed: " . $conn->error;
+        error_log("add-project.php prepare failed: " . $conn->error);
+        echo "Error: something went wrong saving your project. Please try again.";
     }
     $conn->close();
 }

--- a/es/add_project_images.php
+++ b/es/add_project_images.php
@@ -1,7 +1,5 @@
 <?php
 
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
 include '../ecobricks_env.php';
 
 $error_message = '';
@@ -49,7 +47,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             $update_stmt = $conn->prepare($update_sql);
             $update_stmt->bind_param($db_types, ...$db_values);
             if (!$update_stmt->execute()) {
-                $error_message .= "Database update failed: " . $update_stmt->error;
+                error_log("add_project_images.php update failed: " . $update_stmt->error);
+                $error_message .= "Database update failed.";
             }
             $update_stmt->close();
         }

--- a/es/project.php
+++ b/es/project.php
@@ -2,9 +2,7 @@
 <HTML lang="es"> 
 <HEAD>
 <META charset="UTF-8">
-<?php $lang='es';
-error_reporting(E_ALL);
-ini_set('display_errors', 1);?>
+<?php $lang='es';?>
 <?php $version='2.14
 ';?>
 <?php $page='project';?>

--- a/fr/add-project-images.php
+++ b/fr/add-project-images.php
@@ -1,7 +1,5 @@
 <?php
 
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
 include '../ecobricks_env.php';
 
 $error_message = '';
@@ -70,7 +68,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['project_id'])) {
         $update_stmt = $conn->prepare($update_sql);
         $update_stmt->bind_param($db_types, ...$db_values);
         if (!$update_stmt->execute()) {
-            $error_message .= "Database update failed: " . $update_stmt->error;
+            error_log("add-project-images.php update failed: " . $update_stmt->error);
+            $error_message .= "Database update failed.";
         }
         $update_stmt->close();
     }

--- a/fr/add-project.php
+++ b/fr/add-project.php
@@ -1,8 +1,5 @@
 <?php
 
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
-
 include '../ecobricks_env.php';
 $conn->set_charset("utf8mb4");
 
@@ -59,11 +56,13 @@ if ($stmt->execute()) {
         $conn->close();
             echo "<script>window.location.href = 'add-project-images.php?project_id=" . $project_id . "';</script>";
         } else {
-            echo "Error: " . $stmt->error . "<br>";
+            error_log("add-project.php execute failed: " . $stmt->error);
+            echo "Error: something went wrong saving your project. Please try again.<br>";
         }
         $stmt->close();
     } else {
-        echo "Prepare failed: " . $conn->error;
+        error_log("add-project.php prepare failed: " . $conn->error);
+        echo "Error: something went wrong saving your project. Please try again.";
     }
     $conn->close();
 }

--- a/fr/add_project_images.php
+++ b/fr/add_project_images.php
@@ -1,7 +1,5 @@
 <?php
 
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
 include '../ecobricks_env.php';
 
 $error_message = '';
@@ -49,7 +47,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             $update_stmt = $conn->prepare($update_sql);
             $update_stmt->bind_param($db_types, ...$db_values);
             if (!$update_stmt->execute()) {
-                $error_message .= "Database update failed: " . $update_stmt->error;
+                error_log("add_project_images.php update failed: " . $update_stmt->error);
+                $error_message .= "Database update failed.";
             }
             $update_stmt->close();
         }

--- a/fr/project.php
+++ b/fr/project.php
@@ -2,9 +2,7 @@
 <HTML lang="fr"> 
 <HEAD>
 <META charset="UTF-8">
-<?php $lang='fr';
-error_reporting(E_ALL);
-ini_set('display_errors', 1);?>
+<?php $lang='fr';?>
 <?php $version='2.12';?>
 <?php $page='project';?>
 

--- a/id/add-project-images.php
+++ b/id/add-project-images.php
@@ -1,7 +1,5 @@
 <?php
 
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
 include '../ecobricks_env.php';
 
 $error_message = '';
@@ -70,7 +68,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['project_id'])) {
         $update_stmt = $conn->prepare($update_sql);
         $update_stmt->bind_param($db_types, ...$db_values);
         if (!$update_stmt->execute()) {
-            $error_message .= "Database update failed: " . $update_stmt->error;
+            error_log("add-project-images.php update failed: " . $update_stmt->error);
+            $error_message .= "Database update failed.";
         }
         $update_stmt->close();
     }

--- a/id/add-project.php
+++ b/id/add-project.php
@@ -1,8 +1,5 @@
 <?php
 
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
-
 include '../ecobricks_env.php';
 $conn->set_charset("utf8mb4");
 
@@ -59,11 +56,13 @@ if ($stmt->execute()) {
         $conn->close();
             echo "<script>window.location.href = 'add-project-images.php?project_id=" . $project_id . "';</script>";
         } else {
-            echo "Error: " . $stmt->error . "<br>";
+            error_log("add-project.php execute failed: " . $stmt->error);
+            echo "Error: something went wrong saving your project. Please try again.<br>";
         }
         $stmt->close();
     } else {
-        echo "Prepare failed: " . $conn->error;
+        error_log("add-project.php prepare failed: " . $conn->error);
+        echo "Error: something went wrong saving your project. Please try again.";
     }
     $conn->close();
 }

--- a/id/add_project_images.php
+++ b/id/add_project_images.php
@@ -1,7 +1,5 @@
 <?php
 
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
 include '../ecobricks_env.php';
 
 $error_message = '';
@@ -49,7 +47,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             $update_stmt = $conn->prepare($update_sql);
             $update_stmt->bind_param($db_types, ...$db_values);
             if (!$update_stmt->execute()) {
-                $error_message .= "Database update failed: " . $update_stmt->error;
+                error_log("add_project_images.php update failed: " . $update_stmt->error);
+                $error_message .= "Database update failed.";
             }
             $update_stmt->close();
         }

--- a/id/project.php
+++ b/id/project.php
@@ -2,9 +2,7 @@
 <HTML lang="id"> 
 <HEAD>
 <META charset="UTF-8">
-<?php $lang='id';
-error_reporting(E_ALL);
-ini_set('display_errors', 1);?>
+<?php $lang='id';?>
 <?php $version='2.13';?>
 <?php $page='project';?>
 

--- a/scripts/get-ecobricks.php
+++ b/scripts/get-ecobricks.php
@@ -4,8 +4,6 @@
     <meta charset="UTF-8">
     <?php
     $lang = 'en';
-    error_reporting(E_ALL);
-    ini_set('display_errors', 1);
     $version = '1';
     $page = 'project';
     ?>

--- a/scripts/get-training.php
+++ b/scripts/get-training.php
@@ -2,9 +2,7 @@
 <HTML lang="en"> 
 <HEAD>
 <META charset="UTF-8">
-<?php $lang='en';
-error_reporting(E_ALL);
-ini_set('display_errors', 1);?>
+<?php $lang='en';?>
 <?php $version='2.12';?>
 <?php $page='project';?>
 <html>

--- a/scripts/get-training2.php
+++ b/scripts/get-training2.php
@@ -2,9 +2,7 @@
 <HTML lang="en"> 
 <HEAD>
 <META charset="UTF-8">
-<?php $lang='en';
-error_reporting(E_ALL);
-ini_set('display_errors', 1);?>
+<?php $lang='en';?>
 <?php $version='2.12';?>
 <?php $page='project';?>
 <html>

--- a/scripts/newsletter-registration-proxy.php
+++ b/scripts/newsletter-registration-proxy.php
@@ -1,8 +1,4 @@
 <?php
-// Enable error reporting for development
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
-
 header('Access-Control-Allow-Origin: https://book.earthen.io');
 header('Access-Control-Allow-Methods: POST');
 header('Access-Control-Allow-Headers: Content-Type, Authorization');

--- a/scripts/process_ecobrick-full.php
+++ b/scripts/process_ecobrick-full.php
@@ -56,9 +56,6 @@
 <div id="ecobrick-being-processed">
     <div id="ecobricks-processed-gallery">
         <?php
-        ini_set('display_errors', 1);
-        error_reporting(E_ALL);
-
         include '../ecobricks_env.php';
         $conn->set_charset("utf8mb4");
 
@@ -117,7 +114,8 @@
     // Create connection to the database
     $conn = new mysqli($servername, $username, $password, $dbname);
     if ($conn->connect_error) {
-        die("<script>confirm('Connection failed: " . $conn->connect_error . ". Do you want to proceed to the next ecobrick?'); window.location.href = 'process_ecobrick-full.php';</script>");
+        error_log("process_ecobrick-full.php connection failed: " . $conn->connect_error);
+        die("<script>confirm('Connection failed. Do you want to proceed to the next ecobrick?'); window.location.href = 'process_ecobrick-full.php';</script>");
     }
 
     // Prepare filters to get records with field_2492 set to "No" and field_534 containing "Authenticated"
@@ -276,13 +274,15 @@
                     // Record exists, update the existing record
                     $update_stmt = $conn->prepare("UPDATE tb_ecobricks SET serial_no = ?, owner = ?, ecobricker_maker = ?, ecobrick_full_photo_url = ?, volume_ml = ?, universal_volume_ml = ?, weight_g = ?, density = ?, date_logged_ts = ?, CO2_kg = ?, sequestration_type = ?, last_validation_ts = ?, validator_1 = ?, validator_2 = ?, validator_3 = ?, validation_score_avg = ?, knack_record_id = ?, final_validation_score = ?, vision = ?, last_ownership_change = ?, non_registered_maker_name = ?, actual_maker_name = ?, weight_authenticated_kg = ?, location_country = ?, location_region = ?, community_name = ?, brand_name = ?, bottom_colour = ?, plastic_from = ?, ecobrick_brk_display_value = ?, ecobrick_dec_brk_val = ?, ecobrick_brk_amt = ?, photo_choice = ?, location_city = ?, location_full = ?, catalyst = ?, brik_notes = ?, maker_id = ? WHERE ecobrick_unique_id = ?");
                     if ($update_stmt === false) {
-                        echo "<script>if(confirm('Update prepare failed: " . htmlspecialchars($conn->error) . ". Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
+                        error_log("process_ecobrick-full.php update prepare failed: " . $conn->error);
+                        echo "<script>if(confirm('Update prepare failed. Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
                     }
                     $update_stmt->bind_param("sssssssssssssssssssssssssssssssssssssss", $serial_no, $owner, $ecobricker_maker, $ecobrick_full_photo_url, $volume_ml, $universal_volume_ml, $weight_g, $density, $date_logged_ts, $CO2_kg, $sequestration_type, $last_validation_ts, $validator_1, $validator_2, $validator_3, $validation_score_avg, $knack_record_id, $final_validation_score, $vision, $last_ownership_change, $non_registered_maker_name, $actual_maker_name, $weight_authenticated_kg, $location_country, $location_region, $community_name, $brand_name, $bottom_colour, $plastic_from, $ecobrick_brk_display_value, $ecobrick_dec_brk_val, $ecobrick_brk_amt, $photo_choice, $location_city, $location_full, $catalyst, $brik_notes, $maker_id, $ecobrick_unique_id);
 
                     if (!$update_stmt->execute()) {
                         $success = false;
-                        $errors[] = "Update execute failed: " . htmlspecialchars($update_stmt->error);
+                        error_log("process_ecobrick-full.php update execute failed: " . $update_stmt->error);
+                        $errors[] = "Update execute failed.";
                     }
 
                     $update_stmt->close();
@@ -290,13 +290,15 @@
                     // Record does not exist, insert new record
                     $stmt = $conn->prepare("INSERT INTO tb_ecobricks (ecobrick_unique_id, serial_no, owner, ecobricker_maker, ecobrick_full_photo_url, volume_ml, universal_volume_ml, weight_g, density, date_logged_ts, CO2_kg, sequestration_type, last_validation_ts, validator_1, validator_2, validator_3, validation_score_avg, knack_record_id, final_validation_score, vision, last_ownership_change, non_registered_maker_name, actual_maker_name, weight_authenticated_kg, location_country, location_region, community_name, brand_name, bottom_colour, plastic_from, ecobrick_brk_display_value, ecobrick_dec_brk_val, ecobrick_brk_amt, photo_choice, location_city, location_full, catalyst, brik_notes, maker_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
                     if ($stmt === false) {
-                        echo "<script>if(confirm('Prepare failed: " . htmlspecialchars($conn->error) . ". Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
+                        error_log("process_ecobrick-full.php prepare failed: " . $conn->error);
+                        echo "<script>if(confirm('Prepare failed. Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
                     }
                     $stmt->bind_param("sssssssssssssssssssssssssssssssssssssss", $ecobrick_unique_id, $serial_no, $owner, $ecobricker_maker, $ecobrick_full_photo_url, $volume_ml, $universal_volume_ml, $weight_g, $density, $date_logged_ts, $CO2_kg, $sequestration_type, $last_validation_ts, $validator_1, $validator_2, $validator_3, $validation_score_avg, $knack_record_id, $final_validation_score, $vision, $last_ownership_change, $non_registered_maker_name, $actual_maker_name, $weight_authenticated_kg, $location_country, $location_region, $community_name, $brand_name, $bottom_colour, $plastic_from, $ecobrick_brk_display_value, $ecobrick_dec_brk_val, $ecobrick_brk_amt, $photo_choice, $location_city, $location_full, $catalyst, $brik_notes, $maker_id);
 
                     if (!$stmt->execute()) {
                         $success = false;
-                        $errors[] = "Execute failed: " . htmlspecialchars($stmt->error);
+                        error_log("process_ecobrick-full.php execute failed: " . $stmt->error);
+                        $errors[] = "Execute failed.";
                     }
 
                     $stmt->close();
@@ -433,7 +435,8 @@
             $conn = new mysqli($servername, $username, $password, $dbname);
 
             if ($conn->connect_error) {
-                echo "<script>if(confirm('Reconnection failed: " . addslashes($conn->connect_error) . ". Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
+                error_log("process_ecobrick-full.php reconnection failed: " . $conn->connect_error);
+                echo "<script>if(confirm('Reconnection failed. Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
             } else {
                 echo "<script>console.log('Reconnected to the database');</script>";
             }
@@ -443,15 +446,15 @@
 
         $update_stmt = $conn->prepare($update_sql);
         if ($update_stmt === false) {
-            echo "<script>console.log('Prepare failed: " . addslashes($conn->error) . "');</script>";
-            echo "<script>if(confirm('Prepare failed: " . addslashes($conn->error) . ". Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
+            error_log("process_ecobrick-full.php prepare failed: " . $conn->error);
+            echo "<script>if(confirm('Prepare failed. Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
         } else {
             $update_stmt->bind_param($db_types, ...$db_values);
 
             if (!$update_stmt->execute()) {
-                $error_message .= "Database update failed: " . $update_stmt->error;
-                echo "<script>console.log('Database update failed: " . addslashes($update_stmt->error) . "');</script>";
-                echo "<script>if(confirm('Database update failed: " . addslashes($update_stmt->error) . ". Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
+                error_log("process_ecobrick-full.php database update failed: " . $update_stmt->error);
+                $error_message .= "Database update failed.";
+                echo "<script>if(confirm('Database update failed. Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
             } else {
                 echo "<script>console.log('Database updated successfully');</script>";
             }

--- a/scripts/process_ecobrick-old.php
+++ b/scripts/process_ecobrick-old.php
@@ -66,9 +66,6 @@
 
         <?php
 
-        ini_set('display_errors', 1);
-        error_reporting(E_ALL);
-
         include '../ecobricks_env.php';
         $conn->set_charset("utf8mb4");
 
@@ -142,7 +139,8 @@
 
     // Check connection
     if ($conn->connect_error) {
-        die("<script>confirm('Connection failed: " . $conn->connect_error . ". Do you want to proceed to the next ecobrick?'); window.location.href = 'process_ecobricks.php';</script>");
+        error_log("process_ecobrick-old.php connection failed: " . $conn->connect_error);
+        die("<script>confirm('Connection failed. Do you want to proceed to the next ecobrick?'); window.location.href = 'process_ecobricks.php';</script>");
     }
 
     // Prepare filters to get records with field_2492 set to "No" and field_534 containing "Authenticated"
@@ -326,14 +324,16 @@ if (isset($data['records']) && count($data['records']) > 0) {
                 // Prepare and bind
                 $stmt = $conn->prepare("INSERT INTO tb_ecobricks (ecobrick_unique_id, serial_no, owner, ecobricker_maker, ecobrick_full_photo_url, volume_ml, universal_volume_ml, weight_g, density, date_logged_ts, CO2_kg, sequestration_type, last_validation_ts, validator_1, validator_2, validator_3, validation_score_avg, knack_record_id, final_validation_score, vision, last_ownership_change, non_registered_maker_name, actual_maker_name, weight_authenticated_kg, location_country, location_region, community_name, brand_name, bottom_colour, plastic_from, ecobrick_brk_display_value, ecobrick_dec_brk_val, ecobrick_brk_amt, photo_choice, location_city, location_full, catalyst, brik_notes, maker_record_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
                 if ($stmt === false) {
-                    echo "<script>if(confirm('Prepare failed: " . htmlspecialchars($conn->error) . ". Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick.php'; }</script>";
+                    error_log("process_ecobrick-old.php prepare failed: " . $conn->error);
+                    echo "<script>if(confirm('Prepare failed. Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick.php'; }</script>";
                 }
                 $stmt->bind_param("sssssssssssssssssssssssssssssssssssssss", $ecobrick_unique_id, $serial_no, $owner, $ecobricker_maker, $ecobrick_full_photo_url, $volume_ml, $universal_volume_ml, $weight_g, $density, $date_logged_ts, $CO2_kg, $sequestration_type, $last_validation_ts, $validator_1, $validator_2, $validator_3, $validation_score_avg, $knack_record_id, $final_validation_score, $vision, $last_ownership_change, $non_registered_maker_name, $actual_maker_name, $weight_authenticated_kg, $location_country, $location_region, $community_name, $brand_name, $bottom_colour, $plastic_from, $ecobrick_brk_display_value, $ecobrick_dec_brk_val, $ecobrick_brk_amt, $photo_choice, $location_city, $location_full, $catalyst, $brik_notes, $maker_record_id);
 
                 // Execute statement
                 if (!$stmt->execute()) {
                     $success = false;
-                    $errors[] = "Execute failed: " . htmlspecialchars($stmt->error);
+                    error_log("process_ecobrick-old.php execute failed: " . $stmt->error);
+                    $errors[] = "Execute failed.";
                 }
 
                 // Close the statement
@@ -477,7 +477,8 @@ if (!empty($db_fields) && empty($error_message)) {
 
         // Check connection again
         if ($conn->connect_error) {
-            echo "<script>if(confirm('Reconnection failed: " . addslashes($conn->connect_error) . ". Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick.php'; }</script>";
+            error_log("process_ecobrick-old.php reconnection failed: " . $conn->connect_error);
+            echo "<script>if(confirm('Reconnection failed. Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick.php'; }</script>";
         } else {
             echo "<script>console.log('Reconnected to the database');</script>";
         }
@@ -487,15 +488,15 @@ if (!empty($db_fields) && empty($error_message)) {
 
     $update_stmt = $conn->prepare($update_sql);
     if ($update_stmt === false) {
-        echo "<script>console.log('Prepare failed: " . addslashes($conn->error) . "');</script>";
-        echo "<script>if(confirm('Prepare failed: " . addslashes($conn->error) . ". Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick.php'; }</script>";
+        error_log("process_ecobrick-old.php prepare failed: " . $conn->error);
+        echo "<script>if(confirm('Prepare failed. Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick.php'; }</script>";
     } else {
         $update_stmt->bind_param($db_types, ...$db_values);
 
         if (!$update_stmt->execute()) {
-            $error_message .= "Database update failed: " . $update_stmt->error;
-            echo "<script>console.log('Database update failed: " . addslashes($update_stmt->error) . "');</script>";
-            echo "<script>if(confirm('Database update failed: " . addslashes($update_stmt->error) . ". Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick.php'; }</script>";
+            error_log("process_ecobrick-old.php database update failed: " . $update_stmt->error);
+            $error_message .= "Database update failed.";
+            echo "<script>if(confirm('Database update failed. Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick.php'; }</script>";
         } else {
             echo "<script>console.log('Database updated successfully');</script>";
         }

--- a/scripts/process_ecobrick.php
+++ b/scripts/process_ecobrick.php
@@ -56,9 +56,6 @@
 <div id="ecobrick-being-processed">
     <div id="ecobricks-processed-gallery">
         <?php
-        ini_set('display_errors', 1);
-        error_reporting(E_ALL);
-
         include '../ecobricks_env.php';
         $conn->set_charset("utf8mb4");
 
@@ -117,7 +114,8 @@
     // Create connection to the database
     $conn = new mysqli($servername, $username, $password, $dbname);
     if ($conn->connect_error) {
-        die("<script>confirm('Connection failed: " . $conn->connect_error . ". Do you want to proceed to the next ecobrick?'); window.location.href = 'process_ecobrick-full.php';</script>");
+        error_log("process_ecobrick.php connection failed: " . $conn->connect_error);
+        die("<script>confirm('Connection failed. Do you want to proceed to the next ecobrick?'); window.location.href = 'process_ecobrick-full.php';</script>");
     }
 
     // Prepare filters to get records with field_2492 set to "No" and field_534 containing "Authenticated"
@@ -276,13 +274,15 @@
                     // Record exists, update the existing record
                     $update_stmt = $conn->prepare("UPDATE tb_ecobricks SET serial_no = ?, owner = ?, ecobricker_maker = ?, ecobrick_full_photo_url = ?, volume_ml = ?, universal_volume_ml = ?, weight_g = ?, density = ?, date_logged_ts = ?, CO2_kg = ?, sequestration_type = ?, last_validation_ts = ?, validator_1 = ?, validator_2 = ?, validator_3 = ?, validation_score_avg = ?, knack_record_id = ?, final_validation_score = ?, vision = ?, last_ownership_change = ?, non_registered_maker_name = ?, actual_maker_name = ?, weight_authenticated_kg = ?, location_country = ?, location_region = ?, community_name = ?, brand_name = ?, bottom_colour = ?, plastic_from = ?, ecobrick_brk_display_value = ?, ecobrick_dec_brk_val = ?, ecobrick_brk_amt = ?, photo_choice = ?, location_city = ?, location_full = ?, catalyst = ?, brik_notes = ?, maker_id = ? WHERE ecobrick_unique_id = ?");
                     if ($update_stmt === false) {
-                        echo "<script>if(confirm('Update prepare failed: " . htmlspecialchars($conn->error) . ". Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
+                        error_log("process_ecobrick.php update prepare failed: " . $conn->error);
+                        echo "<script>if(confirm('Update prepare failed. Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
                     }
                     $update_stmt->bind_param("sssssssssssssssssssssssssssssssssssssss", $serial_no, $owner, $ecobricker_maker, $ecobrick_full_photo_url, $volume_ml, $universal_volume_ml, $weight_g, $density, $date_logged_ts, $CO2_kg, $sequestration_type, $last_validation_ts, $validator_1, $validator_2, $validator_3, $validation_score_avg, $knack_record_id, $final_validation_score, $vision, $last_ownership_change, $non_registered_maker_name, $actual_maker_name, $weight_authenticated_kg, $location_country, $location_region, $community_name, $brand_name, $bottom_colour, $plastic_from, $ecobrick_brk_display_value, $ecobrick_dec_brk_val, $ecobrick_brk_amt, $photo_choice, $location_city, $location_full, $catalyst, $brik_notes, $maker_id, $ecobrick_unique_id);
 
                     if (!$update_stmt->execute()) {
                         $success = false;
-                        $errors[] = "Update execute failed: " . htmlspecialchars($update_stmt->error);
+                        error_log("process_ecobrick.php update execute failed: " . $update_stmt->error);
+                        $errors[] = "Update execute failed.";
                     }
 
                     $update_stmt->close();
@@ -290,13 +290,15 @@
                     // Record does not exist, insert new record
                     $stmt = $conn->prepare("INSERT INTO tb_ecobricks (ecobrick_unique_id, serial_no, owner, ecobricker_maker, ecobrick_full_photo_url, volume_ml, universal_volume_ml, weight_g, density, date_logged_ts, CO2_kg, sequestration_type, last_validation_ts, validator_1, validator_2, validator_3, validation_score_avg, knack_record_id, final_validation_score, vision, last_ownership_change, non_registered_maker_name, actual_maker_name, weight_authenticated_kg, location_country, location_region, community_name, brand_name, bottom_colour, plastic_from, ecobrick_brk_display_value, ecobrick_dec_brk_val, ecobrick_brk_amt, photo_choice, location_city, location_full, catalyst, brik_notes, maker_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
                     if ($stmt === false) {
-                        echo "<script>if(confirm('Prepare failed: " . htmlspecialchars($conn->error) . ". Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
+                        error_log("process_ecobrick.php prepare failed: " . $conn->error);
+                        echo "<script>if(confirm('Prepare failed. Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
                     }
                     $stmt->bind_param("sssssssssssssssssssssssssssssssssssssss", $ecobrick_unique_id, $serial_no, $owner, $ecobricker_maker, $ecobrick_full_photo_url, $volume_ml, $universal_volume_ml, $weight_g, $density, $date_logged_ts, $CO2_kg, $sequestration_type, $last_validation_ts, $validator_1, $validator_2, $validator_3, $validation_score_avg, $knack_record_id, $final_validation_score, $vision, $last_ownership_change, $non_registered_maker_name, $actual_maker_name, $weight_authenticated_kg, $location_country, $location_region, $community_name, $brand_name, $bottom_colour, $plastic_from, $ecobrick_brk_display_value, $ecobrick_dec_brk_val, $ecobrick_brk_amt, $photo_choice, $location_city, $location_full, $catalyst, $brik_notes, $maker_id);
 
                     if (!$stmt->execute()) {
                         $success = false;
-                        $errors[] = "Execute failed: " . htmlspecialchars($stmt->error);
+                        error_log("process_ecobrick.php execute failed: " . $stmt->error);
+                        $errors[] = "Execute failed.";
                     }
 
                     $stmt->close();
@@ -433,7 +435,8 @@
             $conn = new mysqli($servername, $username, $password, $dbname);
 
             if ($conn->connect_error) {
-                echo "<script>if(confirm('Reconnection failed: " . addslashes($conn->connect_error) . ". Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
+                error_log("process_ecobrick.php reconnection failed: " . $conn->connect_error);
+                echo "<script>if(confirm('Reconnection failed. Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
             } else {
                 echo "<script>console.log('Reconnected to the database');</script>";
             }
@@ -443,15 +446,15 @@
 
         $update_stmt = $conn->prepare($update_sql);
         if ($update_stmt === false) {
-            echo "<script>console.log('Prepare failed: " . addslashes($conn->error) . "');</script>";
-            echo "<script>if(confirm('Prepare failed: " . addslashes($conn->error) . ". Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
+            error_log("process_ecobrick.php prepare failed: " . $conn->error);
+            echo "<script>if(confirm('Prepare failed. Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
         } else {
             $update_stmt->bind_param($db_types, ...$db_values);
 
             if (!$update_stmt->execute()) {
-                $error_message .= "Database update failed: " . $update_stmt->error;
-                echo "<script>console.log('Database update failed: " . addslashes($update_stmt->error) . "');</script>";
-                echo "<script>if(confirm('Database update failed: " . addslashes($update_stmt->error) . ". Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
+                error_log("process_ecobrick.php database update failed: " . $update_stmt->error);
+                $error_message .= "Database update failed.";
+                echo "<script>if(confirm('Database update failed. Do you want to proceed to the next ecobrick?')) { window.location.href = 'process_ecobrick-full.php'; }</script>";
             } else {
                 echo "<script>console.log('Database updated successfully');</script>";
             }

--- a/scripts/process_ecobrick_for_maker_id.php
+++ b/scripts/process_ecobrick_for_maker_id.php
@@ -46,9 +46,6 @@
        <?php
 //PART 1 show latest transfers
 
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
-
 include '../ecobricks_env.php';
 $conn->set_charset("utf8mb4");
 
@@ -118,7 +115,8 @@ $conn = new mysqli($servername, $username, $password, $dbname);
 
 // Check connection
 if ($conn->connect_error) {
-    die("<script>confirm('Connection failed: " . $conn->connect_error . ". Do you want to proceed to the next ecobrick?'); window.location.href = 'process_ecobricks.php';</script>");
+    error_log("process_ecobrick_for_maker_id.php connection failed: " . $conn->connect_error);
+    die("<script>confirm('Connection failed. Do you want to proceed to the next ecobrick?'); window.location.href = 'process_ecobricks.php';</script>");
 }
 
 // Prepare filters to get records with the transfer status field field_2526 set to "No" and field_534 containing "Authenticated"
@@ -243,7 +241,8 @@ $conn2 = new mysqli($servername, $username, $password, $dbname);
 
 // Check connection
 if ($conn2->connect_error) {
-    die("<script>confirm('Connection failed: " . $conn2->connect_error . ". Do you want to proceed to the next ecobrick?'); window.location.href = 'process_ecobricks.php';</script>");
+    error_log("process_ecobrick_for_maker_id.php connection failed: " . $conn2->connect_error);
+    die("<script>confirm('Connection failed. Do you want to proceed to the next ecobrick?'); window.location.href = 'process_ecobricks.php';</script>");
 }
 echo "<p>Connected to Brikchain database...</p>";
 
@@ -257,11 +256,13 @@ if ($stmt_update_ecobrick) {
     if ($stmt_update_ecobrick->execute()) {
         echo "<p>Successfully updated ecobrick with serial number $ecobrick_unique_id. Maker ID set to $maker_record_id.</p>";
     } else {
-        echo "<p>Error updating ecobrick: " . $stmt_update_ecobrick->error . "</p>";
+        error_log("process_ecobrick_for_maker_id.php update failed: " . $stmt_update_ecobrick->error);
+        echo "<p>Error updating ecobrick.</p>";
     }
     $stmt_update_ecobrick->close();
 } else {
-    echo "<p>Error preparing statement: " . $conn2->error . "</p>";
+    error_log("process_ecobrick_for_maker_id.php prepare failed: " . $conn2->error);
+    echo "<p>Error preparing statement.</p>";
 }
 
 $conn2->close();

--- a/scripts/process_training.php
+++ b/scripts/process_training.php
@@ -14,7 +14,8 @@ $conn = new mysqli($servername, $username, $password, $dbname);
 
 // Check connection
 if ($conn->connect_error) {
-    die("<script>confirm('Connection failed: " . $conn->connect_error . ". Do you want to proceed to the next training?'); window.location.href = 'process_training.php?training_id=" . ($training_id + 1) . "';</script>");
+    error_log("process_training.php connection failed: " . $conn->connect_error);
+    die("<script>confirm('Connection failed. Do you want to proceed to the next training?'); window.location.href = 'process_training.php?training_id=" . ($training_id + 1) . "';</script>");
 }
 
 // Prepare filters
@@ -115,14 +116,16 @@ if (isset($data['records']) && count($data['records']) > 0) {
                 // Prepare and bind
                 $stmt = $conn->prepare("INSERT INTO tb_trainings (training_id, training_title, training_date, no_participants, lead_trainer, training_photo0_main, training_photo1_main, training_photo2_main, training_photo3_main, training_photo4_main, training_photo5_main, training_photo6_main, training_type, briks_made, est_plastic_packed, location_full, training_summary, training_agenda, training_success, training_challenges, training_lessons_learned) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
                 if ($stmt === false) {
-                    echo "<script>if(confirm('Prepare failed: " . htmlspecialchars($conn->error) . ". Do you want to proceed to the next training?')) { window.location.href = 'process_training2.php?training_id=" . ($training_id + 1) . "'; }</script>";
+                    error_log("process_training.php prepare failed: " . $conn->error);
+                    echo "<script>if(confirm('Prepare failed. Do you want to proceed to the next training?')) { window.location.href = 'process_training2.php?training_id=" . ($training_id + 1) . "'; }</script>";
                 }
                 $stmt->bind_param("sssssssssssssssssssss", $training_id, $training_title, $training_date, $no_participants, $lead_trainer, $training_photo0_main, $training_photo1_main, $training_photo2_main, $training_photo3_main, $training_photo4_main, $training_photo5_main, $training_photo6_main, $training_type, $briks_made, $est_plastic_packed, $location_full, $training_summary, $training_agenda, $training_success, $training_challenges, $training_lessons_learned);
 
                 // Execute statement
                 if (!$stmt->execute()) {
                     $success = false;
-                    $errors[] = "Execute failed: " . htmlspecialchars($stmt->error);
+                    error_log("process_training.php execute failed: " . $stmt->error);
+                    $errors[] = "Execute failed.";
                 }
 
                 // Close the statement
@@ -276,7 +279,8 @@ if (!empty($db_fields) && empty($error_message)) {
 
         // Check connection again
         if ($conn->connect_error) {
-            echo "<script>if(confirm('Reconnection failed: " . addslashes($conn->connect_error) . ". Do you want to proceed to the next training?')) { window.location.href = 'training.php?training_id=" . ($training_id + 1) . "'; }</script>";
+            error_log("process_training.php reconnection failed: " . $conn->connect_error);
+            echo "<script>if(confirm('Reconnection failed. Do you want to proceed to the next training?')) { window.location.href = 'training.php?training_id=" . ($training_id + 1) . "'; }</script>";
         } else {
             echo "<script>console.log('Reconnected to the database');</script>";
         }
@@ -284,15 +288,15 @@ if (!empty($db_fields) && empty($error_message)) {
 
     $update_stmt = $conn->prepare($update_sql);
     if ($update_stmt === false) {
-        echo "<script>console.log('Prepare failed: " . addslashes($conn->error) . "');</script>";
-        echo "<script>if(confirm('Prepare failed: " . addslashes($conn->error) . ". Do you want to proceed to the next training?')) { window.location.href = 'training.php?training_id=" . ($training_id + 1) . "'; }</script>";
+        error_log("process_training.php prepare failed: " . $conn->error);
+        echo "<script>if(confirm('Prepare failed. Do you want to proceed to the next training?')) { window.location.href = 'training.php?training_id=" . ($training_id + 1) . "'; }</script>";
     } else {
         $update_stmt->bind_param($db_types, ...$db_values);
 
         if (!$update_stmt->execute()) {
-            $error_message .= "Database update failed: " . $update_stmt->error;
-            echo "<script>console.log('Database update failed: " . addslashes($update_stmt->error) . "');</script>";
-            echo "<script>if(confirm('Database update failed: " . addslashes($update_stmt->error) . ". Do you want to proceed to the next training?')) { window.location.href = 'training.php?training_id=" . ($training_id + 1) . "'; }</script>";
+            error_log("process_training.php database update failed: " . $update_stmt->error);
+            $error_message .= "Database update failed.";
+            echo "<script>if(confirm('Database update failed. Do you want to proceed to the next training?')) { window.location.href = 'training.php?training_id=" . ($training_id + 1) . "'; }</script>";
         } else {
             echo "<script>console.log('Database updated successfully');</script>";
         }

--- a/scripts/process_training2.php
+++ b/scripts/process_training2.php
@@ -15,7 +15,8 @@ $conn = new mysqli($servername, $username, $password, $dbname);
 
 // Check connection
 if ($conn->connect_error) {
-    die("<script>alert('Connection failed: " . $conn->connect_error . "');</script>");
+    error_log("process_training2.php connection failed: " . $conn->connect_error);
+    die("<script>alert('Connection failed.');</script>");
 }
 
 // Prepare filters
@@ -116,14 +117,16 @@ if (isset($data['records']) && count($data['records']) > 0) {
                 // Prepare and bind
                 $stmt = $conn->prepare("INSERT INTO tb_trainings (training_id, training_title, training_date, no_participants, lead_trainer, training_photo0_main, training_photo1_main, training_photo2_main, training_photo3_main, training_photo4_main, training_photo5_main, training_photo6_main, training_type, briks_made, est_plastic_packed, location_full, training_summary, training_agenda, training_success, training_challenges, training_lessons_learned) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
                 if ($stmt === false) {
-                    die("<script>alert('Prepare failed: " . htmlspecialchars($conn->error) . "');</script>");
+                    error_log("process_training2.php prepare failed: " . $conn->error);
+                    die("<script>alert('Prepare failed.');</script>");
                 }
                 $stmt->bind_param("sssssssssssssssssssss", $training_id, $training_title, $training_date, $no_participants, $lead_trainer, $training_photo0_main, $training_photo1_main, $training_photo2_main, $training_photo3_main, $training_photo4_main, $training_photo5_main, $training_photo6_main, $training_type, $briks_made, $est_plastic_packed, $location_full, $training_summary, $training_agenda, $training_success, $training_challenges, $training_lessons_learned);
 
                 // Execute statement
                 if (!$stmt->execute()) {
                     $success = false;
-                    $errors[] = "Execute failed: " . htmlspecialchars($stmt->error);
+                    error_log("process_training2.php execute failed: " . $stmt->error);
+                    $errors[] = "Execute failed.";
                 }
                 
                 // Close the statement
@@ -238,9 +241,6 @@ for ($i = 0; $i < 7; $i++) {
 }
 
 
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
-
 if (!empty($db_fields) && empty($error_message)) {
     echo "<script>console.log('Updating database with new image data');</script>";
 
@@ -269,7 +269,8 @@ if (!empty($db_fields) && empty($error_message)) {
 
         // Check connection again
         if ($conn->connect_error) {
-            die("<script>alert('Reconnection failed: " . $conn->connect_error . "');</script>");
+            error_log("process_training2.php reconnection failed: " . $conn->connect_error);
+            die("<script>alert('Reconnection failed.');</script>");
         } else {
             echo "<script>console.log('Reconnected to the database');</script>";
         }
@@ -277,14 +278,14 @@ if (!empty($db_fields) && empty($error_message)) {
 
     $update_stmt = $conn->prepare($update_sql);
     if ($update_stmt === false) {
-        echo "<script>console.log('Prepare failed: " . addslashes($conn->error) . "');</script>";
-        die("Prepare failed: " . $conn->error);
+        error_log("process_training2.php prepare failed: " . $conn->error);
+        die("Prepare failed.");
     }
     $update_stmt->bind_param($db_types, ...$db_values);
 
     if (!$update_stmt->execute()) {
-        $error_message .= "Database update failed: " . $update_stmt->error;
-        echo "<script>console.log('Database update failed: " . addslashes($update_stmt->error) . "');</script>";
+        error_log("process_training2.php database update failed: " . $update_stmt->error);
+        $error_message .= "Database update failed.";
     } else {
         echo "<script>console.log('Database updated successfully');</script>";
     }

--- a/scripts/process_training3.php
+++ b/scripts/process_training3.php
@@ -14,7 +14,8 @@ $conn = new mysqli($servername, $username, $password, $dbname);
 
 // Check connection
 if ($conn->connect_error) {
-    die("<script>confirm('Connection failed: " . $conn->connect_error . ". Do you want to proceed to the next training?'); window.location.href = 'process_training.php?training_id=" . ($training_id + 1) . "';</script>");
+    error_log("process_training3.php connection failed: " . $conn->connect_error);
+    die("<script>confirm('Connection failed. Do you want to proceed to the next training?'); window.location.href = 'process_training.php?training_id=" . ($training_id + 1) . "';</script>");
 }
 
 // Prepare filters
@@ -115,14 +116,16 @@ if (isset($data['records']) && count($data['records']) > 0) {
                 // Prepare and bind
                 $stmt = $conn->prepare("INSERT INTO tb_trainings (training_id, training_title, training_date, no_participants, lead_trainer, training_photo0_main, training_photo1_main, training_photo2_main, training_photo3_main, training_photo4_main, training_photo5_main, training_photo6_main, training_type, briks_made, est_plastic_packed, location_full, training_summary, training_agenda, training_success, training_challenges, training_lessons_learned) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
                 if ($stmt === false) {
-                    echo "<script>if(confirm('Prepare failed: " . htmlspecialchars($conn->error) . ". Do you want to proceed to the next training?')) { window.location.href = 'process_training2.php?training_id=" . ($training_id + 1) . "'; }</script>";
+                    error_log("process_training3.php prepare failed: " . $conn->error);
+                    echo "<script>if(confirm('Prepare failed. Do you want to proceed to the next training?')) { window.location.href = 'process_training2.php?training_id=" . ($training_id + 1) . "'; }</script>";
                 }
                 $stmt->bind_param("sssssssssssssssssssss", $training_id, $training_title, $training_date, $no_participants, $lead_trainer, $training_photo0_main, $training_photo1_main, $training_photo2_main, $training_photo3_main, $training_photo4_main, $training_photo5_main, $training_photo6_main, $training_type, $briks_made, $est_plastic_packed, $location_full, $training_summary, $training_agenda, $training_success, $training_challenges, $training_lessons_learned);
 
                 // Execute statement
                 if (!$stmt->execute()) {
                     $success = false;
-                    $errors[] = "Execute failed: " . htmlspecialchars($stmt->error);
+                    error_log("process_training3.php execute failed: " . $stmt->error);
+                    $errors[] = "Execute failed.";
                 }
 
                 // Close the statement
@@ -276,7 +279,8 @@ if (!empty($db_fields) && empty($error_message)) {
 
         // Check connection again
         if ($conn->connect_error) {
-            echo "<script>if(confirm('Reconnection failed: " . addslashes($conn->connect_error) . ". Do you want to proceed to the next training?')) { window.location.href = 'training.php?training_id=" . ($training_id + 1) . "'; }</script>";
+            error_log("process_training3.php reconnection failed: " . $conn->connect_error);
+            echo "<script>if(confirm('Reconnection failed. Do you want to proceed to the next training?')) { window.location.href = 'training.php?training_id=" . ($training_id + 1) . "'; }</script>";
         } else {
             echo "<script>console.log('Reconnected to the database');</script>";
         }
@@ -284,15 +288,15 @@ if (!empty($db_fields) && empty($error_message)) {
 
     $update_stmt = $conn->prepare($update_sql);
     if ($update_stmt === false) {
-        echo "<script>console.log('Prepare failed: " . addslashes($conn->error) . "');</script>";
-        echo "<script>if(confirm('Prepare failed: " . addslashes($conn->error) . ". Do you want to proceed to the next training?')) { window.location.href = 'training.php?training_id=" . ($training_id + 1) . "'; }</script>";
+        error_log("process_training3.php prepare failed: " . $conn->error);
+        echo "<script>if(confirm('Prepare failed. Do you want to proceed to the next training?')) { window.location.href = 'training.php?training_id=" . ($training_id + 1) . "'; }</script>";
     } else {
         $update_stmt->bind_param($db_types, ...$db_values);
 
         if (!$update_stmt->execute()) {
-            $error_message .= "Database update failed: " . $update_stmt->error;
-            echo "<script>console.log('Database update failed: " . addslashes($update_stmt->error) . "');</script>";
-            echo "<script>if(confirm('Database update failed: " . addslashes($update_stmt->error) . ". Do you want to proceed to the next training?')) { window.location.href = 'training.php?training_id=" . ($training_id + 1) . "'; }</script>";
+            error_log("process_training3.php database update failed: " . $update_stmt->error);
+            $error_message .= "Database update failed.";
+            echo "<script>if(confirm('Database update failed. Do you want to proceed to the next training?')) { window.location.href = 'training.php?training_id=" . ($training_id + 1) . "'; }</script>";
         } else {
             echo "<script>console.log('Database updated successfully');</script>";
         }

--- a/scripts/training.php
+++ b/scripts/training.php
@@ -8,7 +8,8 @@ $conn = new mysqli($servername, $username, $password, $dbname);
 
 // Check connection
 if ($conn->connect_error) {
-    die("<script>alert('Connection failed: " . $conn->connect_error . "');</script>");
+    error_log("training.php connection failed: " . $conn->connect_error);
+    die("<script>alert('Connection failed.');</script>");
 }
 
 // Check if the form is submitted to delete the training
@@ -21,7 +22,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['action']) && $_POST['a
     if ($delete_stmt->execute()) {
         echo "<script>alert('Training deleted successfully.'); window.location.href='get-training.php';</script>";
     } else {
-        echo "<script>alert('Error deleting training: " . $delete_stmt->error . "');</script>";
+        error_log("training.php delete failed: " . $delete_stmt->error);
+        echo "<script>alert('Error deleting training.');</script>";
     }
 
     $delete_stmt->close();

--- a/scripts/update-training-database.php
+++ b/scripts/update-training-database.php
@@ -9,7 +9,8 @@ $conn = new mysqli($servername, $username, $password, $dbname);
 
 // Check connection
 if ($conn->connect_error) {
-    die("<script>alert('Connection failed: " . $conn->connect_error . "');</script>");
+    error_log("update-training-database.php connection failed: " . $conn->connect_error);
+    die("<script>alert('Connection failed.');</script>");
 }
 
 echo "<div class='message'>Updating database with new image data</div>";
@@ -69,7 +70,8 @@ if ($conn->ping()) {
 
     // Check connection again
     if ($conn->connect_error) {
-        echo "<div class='alert'>Reconnection failed: " . $conn->connect_error . "</div>";
+        error_log("update-training-database.php reconnection failed: " . $conn->connect_error);
+        echo "<div class='alert'>Reconnection failed.</div>";
         ob_flush(); flush();
         exit;
     } else {
@@ -80,15 +82,17 @@ if ($conn->ping()) {
 
 $update_stmt = $conn->prepare($update_sql);
 if ($update_stmt === false) {
-    echo "<div class='alert'>Prepare failed: " . htmlspecialchars($conn->error) . "</div>";
+    error_log("update-training-database.php prepare failed: " . $conn->error);
+    echo "<div class='alert'>Prepare failed.</div>";
     ob_flush(); flush();
     exit;
 }
 $update_stmt->bind_param($db_types, ...$db_values);
 
 if (!$update_stmt->execute()) {
-    $error_message .= "Database update failed: " . $update_stmt->error;
-    echo "<div class='alert'>Database update failed: " . htmlspecialchars($update_stmt->error) . "</div>";
+    error_log("update-training-database.php update failed: " . $update_stmt->error);
+    $error_message .= "Database update failed.";
+    echo "<div class='alert'>Database update failed.</div>";
     ob_flush(); flush();
 } else {
     echo "<div class='message'>Database updated successfully</div>";


### PR DESCRIPTION
## Summary

Two related information-disclosure issues, fixed together since they're both about errors leaking to end users:

**1. Hardcoded `display_errors` in ~29 files.** Files like `404-handler.php`, `en/project.php`, `es/add-project.php`, `scripts/get-training.php`, `api/fetch_cash_trans.php`, etc. had:
```php
ini_set('display_errors', 1);
error_reporting(E_ALL);
```
This forces PHP to print stack traces and internal file paths to *any* visitor, overriding whatever the production server's own `php.ini` says. Removed these overrides everywhere so the server's own production settings (which should have `display_errors` off) actually take effect. Where the line closed the PHP tag inline (`ini_set(...);?>`), preserved the `?>` and only removed the ini_set/error_reporting calls, verified with `php -l` on every changed file.

**2. Raw DB errors echoed straight to responses.** E.g. `api/fetch_cash_trans.php` did:
```php
echo json_encode(['error' => 'Failed to prepare database query: ' . $gobrik_conn->error]);
```
Anyone hitting the endpoint with a malformed request got the actual MySQL error string back. Replaced every occurrence (public `/api/` endpoints, the public `add-project`/`add-project-images` forms in es/fr/id, and the `/scripts/` admin migration tools) with a generic message + `error_log(...)` so the real error is still available to whoever has server log access, just not to the requester.

## Testing

No test suite/CI in this repo, and no DB credentials available locally (`ecobricks_env.php`/`gobrikconn_env.php` intentionally not committed). Verified with:
- `php -l` on all 35 changed files — no new syntax errors (pre-existing unrelated `(double)` cast deprecation notices in a few `add-project.php` files are untouched, confirmed present before this change too).
- Manual review of every diff to confirm control flow is unchanged (e.g. `$errors[]`/`$error_message` are still populated so `if (!empty($error_message))` branches still fire correctly, just with generic text instead of the raw driver error).

Recommend a quick smoke test on staging/`beta.ecobricks.org`: submit the `add-project` form and the `/api/fetch_cash_trans.php` endpoint with an invalid ID and confirm you get a clean generic error instead of a PHP warning or raw SQL error text.