### PR TITLE
Add robots.txt and Referrer-Policy meta tag

### DIFF
--- a/header-2025.php
+++ b/header-2025.php
@@ -8,6 +8,7 @@
 
 	<link rel="canonical" href="https://ecobricks.org/<?php echo ($lang); ;?>/<?php echo ($name); ;?>">
 	<meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+	<meta name="referrer" content="strict-origin-when-cross-origin">
 
 	<link rel="alternate" href="https://ecobricks.org/en/<?php echo ($name); ;?>" hreflang="en">
 	<link rel="alternate" href="https://ecobricks.org/id/<?php echo ($name); ;?>" hreflang="id">

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,9 @@
+User-agent: *
+Disallow: /scripts/
+Disallow: /api/
+Disallow: /includes/
+Disallow: /meta/
+Disallow: /translations/
+
+Sitemap: https://ecobricks.org/sitemap.xml
+Sitemap: https://ecobricks.org/sitemap-multilingual.xml


### PR DESCRIPTION
## Summary

- **Adds `robots.txt`** disallowing `/scripts/`, `/api/`, `/includes/`, `/meta/`, `/translations/` — none of these are meant to be visited as standalone pages (they're internal admin tools, raw JSON endpoints, or PHP/JS partials `require`'d by real pages), so there's no reason for them to be crawled or indexed. Points to both `sitemap.xml` and `sitemap-multilingual.xml`.
- **Adds `<meta name="referrer" content="strict-origin-when-cross-origin">`** to `header-2025.php`, which is loaded on every page.

## Why not the other usual security headers (X-Content-Type-Options, X-Frame-Options, HSTS, CSP)?

Wanted to flag this rather than silently skip it or half-implement something that looks like it works but doesn't:

1. This repo's own `.gitignore` has `.htaccess*` under "Core server / hosting clutter" — `.htaccess` is explicitly excluded from version control here, presumably because it's managed directly on the live server. Adding one in this PR would go against that existing convention (and could conflict with whatever the server already has).
2. Setting these via PHP's `header()` doesn't work as an alternative: every page (`en/how.php`, etc.) starts with literal `<!DOCTYPE html>` output *before* `includes/{page}-inc2.php` requires `header-2025.php` — so a `header()` call placed in `header-2025.php` would hit "headers already sent" on every real page and silently no-op.
3. `<meta>` tags don't have that "already sent" restriction, which is why `Referrer-Policy` could be done this way — but `X-Content-Type-Options` and `X-Frame-Options` have **no meta-tag equivalent** that any browser honors; they require a real HTTP header.
4. CSP could technically go in a `<meta http-equiv="Content-Security-Policy">` tag, but I didn't want to guess at a policy without being able to test it against every external resource the site actually loads (fonts.googleapis.com, unpkg.com/leaflet, SVGator, Facebook widgets, etc.) — a wrong CSP silently breaks functionality rather than failing loudly.

**Recommendation:** add `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, and HSTS directly in the live server's `.htaccess`/vhost config (outside this repo, consistent with how `.htaccess` is already handled). Happy to help draft a CSP in a follow-up if someone can test it against staging/`beta.ecobricks.org` first.

## Testing

- Confirmed `robots.txt` isn't caught by any existing `.gitignore` rule (`git check-ignore` returns nothing).
- `php -l` on `header-2025.php` — no syntax errors.
- No test suite/CI in this repo to run beyond that.